### PR TITLE
Add item data cache to RPCache/RPData

### DIFF
--- a/Sources/RPTrunk/Data/Cache.swift
+++ b/Sources/RPTrunk/Data/Cache.swift
@@ -66,21 +66,21 @@ open class RPCache<RP: RPSpace> {
     }
 
     public func loadItems(_ items: [String: ItemJSON<RP>]) throws {
-        try items.forEach { (cacheId, data) in
+        try items.forEach { (code, data) in
             let components: [Component<RP>] = try buildComponent(data)
             let ability = try data.ability.map { try getAbility($0) }
             let conditional = Conditional<RP>(data.conditional ?? "always")
             var item = RPItem<RP>(components: components, ability: ability, conditional: conditional)
-            item.cacheId = cacheId
-            item.name = cacheId
+            item.code = code
+            item.name = code
             item.metadata = data.metadata
-            self.items[cacheId] = item
+            self.items[code] = item
         }
     }
 
-    public func newItem(_ cacheId: RPItemCacheId) throws -> RPItem<RP> {
-        guard var item = items[cacheId] else {
-            throw RPCache.CacheError.notFound(cacheId)
+    public func newItem(_ code: RPItemCode) throws -> RPItem<RP> {
+        guard var item = items[code] else {
+            throw RPCache.CacheError.notFound(code)
         }
         item.id = UUID().uuidString
         return item

--- a/Sources/RPTrunk/Data/Cache.swift
+++ b/Sources/RPTrunk/Data/Cache.swift
@@ -8,8 +8,8 @@ open class RPCache<RP: RPSpace> {
     
     typealias AbilityData = AbilityJSON<RP>
 
-    public var abilities: [RPReferenceCode: Ability<RP>] = [:]
-    public var statusEffects: [RPReferenceCode: StatusEffect<RP>] = [:]
+    public var abilities: [RPReferenceCode: RPAbility<RP>] = [:]
+    public var statusEffects: [RPReferenceCode: RPStatusEffect<RP>] = [:]
     public var entities: [RPReferenceCode: RPEntity<RP>] = [:]
     public var items: [RPReferenceCode: RPItem<RP>] = [:]
 
@@ -25,7 +25,7 @@ open class RPCache<RP: RPSpace> {
     public func loadAbilities(_ abilities: [RPReferenceCode: AbilityJSON<RP>]) throws {
         try abilities.forEach { (code, data) in
             let components: [Component] = try buildComponent(data)
-            var ability = Ability<RP>(code: code, displayName: data.displayName, components: components, cooldown: data.cooldown)
+            var ability = RPAbility<RP>(code: code, displayName: data.displayName, components: components, cooldown: data.cooldown)
             ability.metadata = data.metadata
             self.abilities[code] = ability
         }
@@ -34,7 +34,7 @@ open class RPCache<RP: RPSpace> {
     public func loadStatusEffects(_ statusEffects: [RPReferenceCode: StatusEffectJSON<RP>]) throws {
         try statusEffects.forEach { (code, data) in
             let components: [Component<RP>] = try buildComponent(data)
-            let se = StatusEffect<RP>(
+            let se = RPStatusEffect<RP>(
                 code: code,
                 displayName: data.displayName,
                 tags: [],
@@ -42,7 +42,7 @@ open class RPCache<RP: RPSpace> {
                 duration: data.duration,
                 charges: data.charges,
                 impairsAction: data.impairsAction ?? false,
-                period: data.period ?? StatusEffect<RP>.defaultPeriod
+                period: data.period ?? RPStatusEffect<RP>.defaultPeriod
             )
             self.statusEffects[code] = se
         }
@@ -112,7 +112,7 @@ open class RPCache<RP: RPSpace> {
             components += try statusEffects.map { try getStatusEffect($0) }
         }
         if let target = component.target {
-            let type = Targeting<RP>.fromString(target)
+            let type = RPTargeting<RP>.fromString(target)
             components.append(Component<RP>(targetType: type))
         }
         if let discharge = component.discharge {
@@ -132,7 +132,7 @@ open class RPCache<RP: RPSpace> {
         return .always
     }
 
-    public func getAbility(_ name: String) throws -> Ability<RP> {
+    public func getAbility(_ name: String) throws -> RPAbility<RP> {
         if let ability = abilities[name] {
             return ability
         }

--- a/Sources/RPTrunk/Data/Cache.swift
+++ b/Sources/RPTrunk/Data/Cache.swift
@@ -5,6 +5,8 @@ open class RPCache<RP: RPSpace> {
         case notFound(String)
         case invalidFormat(String)
     }
+    
+    typealias AbilityData = AbilityJSON<RP>
 
     public var abilities: [String: Ability<RP>] = [:]
     public var statusEffects: [String: StatusEffect<RP>] = [:]
@@ -13,14 +15,14 @@ open class RPCache<RP: RPSpace> {
 
     public init() {}
 
-    public func load(_ data: RPCacheJSON<RP.Stats>) throws {
+    public func load(_ data: RPCacheJSON<RP>) throws {
         try loadStatusEffects(data.statusEffects ?? [:])
         try loadAbilities(data.abilities ?? [:])
         try loadEntities(data.entities ?? [:])
         try loadItems(data.items ?? [:])
     }
 
-    public func loadAbilities(_ abilities: [String: AbilityJSON<RP.Stats>]) throws {
+    public func loadAbilities(_ abilities: [String: AbilityJSON<RP>]) throws {
         try abilities.forEach { (name, data) in
             let components: [Component] = try buildComponent(data)
             var ability = Ability<RP>(name: name, components: components, cooldown: data.cooldown)
@@ -29,7 +31,7 @@ open class RPCache<RP: RPSpace> {
         }
     }
 
-    public func loadStatusEffects(_ statusEffects: [String: StatusEffectJSON<RP.Stats>]) throws {
+    public func loadStatusEffects(_ statusEffects: [String: StatusEffectJSON<RP>]) throws {
         try statusEffects.forEach { (name, data) in
             let components: [Component<RP>] = try buildComponent(data)
             let se = StatusEffect<RP>(
@@ -45,7 +47,7 @@ open class RPCache<RP: RPSpace> {
         }
     }
 
-    public func loadEntities(_ entities: [String: EntityJSON<RP.Stats>]) throws {
+    public func loadEntities(_ entities: [String: EntityJSON<RP>]) throws {
         entities.forEach {(name, data) in
             let stats = data.stats ?? .zero
             var entity = RPEntity<RP>.new(cache: self)
@@ -63,21 +65,22 @@ open class RPCache<RP: RPSpace> {
         }
     }
 
-    public func loadItems(_ items: [String: ItemJSON<RP.Stats>]) throws {
-        try items.forEach { (name, data) in
+    public func loadItems(_ items: [String: ItemJSON<RP>]) throws {
+        try items.forEach { (cacheId, data) in
             let components: [Component<RP>] = try buildComponent(data)
             let ability = try data.ability.map { try getAbility($0) }
             let conditional = Conditional<RP>(data.conditional ?? "always")
             var item = RPItem<RP>(components: components, ability: ability, conditional: conditional)
-            item.name = name
+            item.cacheId = cacheId
+            item.name = cacheId
             item.metadata = data.metadata
-            self.items[name] = item
+            self.items[cacheId] = item
         }
     }
 
-    public func newItem(_ name: String) throws -> RPItem<RP> {
-        guard var item = items[name] else {
-            throw RPCache.CacheError.notFound(name)
+    public func newItem(_ cacheId: RPItemCacheId) throws -> RPItem<RP> {
+        guard var item = items[cacheId] else {
+            throw RPCache.CacheError.notFound(cacheId)
         }
         item.id = UUID().uuidString
         return item

--- a/Sources/RPTrunk/Data/Cache.swift
+++ b/Sources/RPTrunk/Data/Cache.swift
@@ -72,20 +72,28 @@ open class RPCache<RP: RPSpace> {
             let components: [Component<RP>] = try buildComponent(data)
             let ability = try data.ability.map { try getAbility($0) }
             let conditional = Conditional<RP>(data.conditional ?? "always")
-            var item = RPItem<RP>(components: components, ability: ability, conditional: conditional)
-            item.code = code
-            item.displayName = data.displayName ?? code
+            var item = RPItem<RP>(
+                code: code,
+                displayName: data.displayName,
+                maximumStack: data.maximumStack,
+                components: components,
+                ability: ability,
+                conditional: conditional
+            )
             item.metadata = data.metadata
             self.items[code] = item
         }
     }
 
-    public func newItem(_ code: RPReferenceCode) throws -> RPItem<RP> {
-        guard var item = items[code] else {
+    public func getItem(_ code: RPReferenceCode) throws -> RPItem<RP> {
+        guard let item = items[code] else {
             throw RPCache.CacheError.notFound(code)
         }
-        item.id = UUID().uuidString
         return item
+    }
+
+    public func newActiveItem(_ code: RPReferenceCode, amount: Int = 1) throws -> RPActiveItem<RP> {
+        RPActiveItem(item: try getItem(code), amount: amount)
     }
 
     public func buildComponent<C: ComponentsContainerJSON>(_ component: C) throws -> [Component<RP>] where C.Stats == RP.Stats  {

--- a/Sources/RPTrunk/Data/Cache.swift
+++ b/Sources/RPTrunk/Data/Cache.swift
@@ -8,10 +8,10 @@ open class RPCache<RP: RPSpace> {
     
     typealias AbilityData = AbilityJSON<RP>
 
-    public var abilities: [String: Ability<RP>] = [:]
-    public var statusEffects: [String: StatusEffect<RP>] = [:]
-    public var entities: [String: RPEntity<RP>] = [:]
-    public var items: [String: RPItem<RP>] = [:]
+    public var abilities: [RPReferenceCode: Ability<RP>] = [:]
+    public var statusEffects: [RPReferenceCode: StatusEffect<RP>] = [:]
+    public var entities: [RPReferenceCode: RPEntity<RP>] = [:]
+    public var items: [RPReferenceCode: RPItem<RP>] = [:]
 
     public init() {}
 
@@ -22,20 +22,21 @@ open class RPCache<RP: RPSpace> {
         try loadItems(data.items ?? [:])
     }
 
-    public func loadAbilities(_ abilities: [String: AbilityJSON<RP>]) throws {
-        try abilities.forEach { (name, data) in
+    public func loadAbilities(_ abilities: [RPReferenceCode: AbilityJSON<RP>]) throws {
+        try abilities.forEach { (code, data) in
             let components: [Component] = try buildComponent(data)
-            var ability = Ability<RP>(name: name, components: components, cooldown: data.cooldown)
+            var ability = Ability<RP>(code: code, displayName: data.displayName, components: components, cooldown: data.cooldown)
             ability.metadata = data.metadata
-            self.abilities[name] = ability
+            self.abilities[code] = ability
         }
     }
 
-    public func loadStatusEffects(_ statusEffects: [String: StatusEffectJSON<RP>]) throws {
-        try statusEffects.forEach { (name, data) in
+    public func loadStatusEffects(_ statusEffects: [RPReferenceCode: StatusEffectJSON<RP>]) throws {
+        try statusEffects.forEach { (code, data) in
             let components: [Component<RP>] = try buildComponent(data)
             let se = StatusEffect<RP>(
-                name: name,
+                code: code,
+                displayName: data.displayName,
                 tags: [],
                 components: components,
                 duration: data.duration,
@@ -43,42 +44,43 @@ open class RPCache<RP: RPSpace> {
                 impairsAction: data.impairsAction ?? false,
                 period: data.period ?? StatusEffect<RP>.defaultPeriod
             )
-            self.statusEffects[name] = se
+            self.statusEffects[code] = se
         }
     }
 
-    public func loadEntities(_ entities: [String: EntityJSON<RP>]) throws {
-        entities.forEach {(name, data) in
+    public func loadEntities(_ entities: [RPReferenceCode: EntityJSON<RP>]) throws {
+        entities.forEach {(code, data) in
             let stats = data.stats ?? .zero
             var entity = RPEntity<RP>.new(cache: self)
+            entity.code = code
             entity.baseStats = stats
-            entity.displayName = data.displayName ?? "?!?!"
+            entity.displayName = data.displayName ?? code
             entity.currentStats = stats
             data.abilities?.forEach {
                 ability in
                 let conditional = Conditional<RP>(ability.conditional)
-                if let ability = self.abilities[ability.name] {
+                if let ability = self.abilities[ability.code] {
                     entity.addExecutableAbility(ability, conditional: conditional)
                 }
             }
-            self.entities[name] = entity
+            self.entities[code] = entity
         }
     }
 
-    public func loadItems(_ items: [String: ItemJSON<RP>]) throws {
+    public func loadItems(_ items: [RPReferenceCode: ItemJSON<RP>]) throws {
         try items.forEach { (code, data) in
             let components: [Component<RP>] = try buildComponent(data)
             let ability = try data.ability.map { try getAbility($0) }
             let conditional = Conditional<RP>(data.conditional ?? "always")
             var item = RPItem<RP>(components: components, ability: ability, conditional: conditional)
             item.code = code
-            item.name = code
+            item.displayName = data.displayName ?? code
             item.metadata = data.metadata
             self.items[code] = item
         }
     }
 
-    public func newItem(_ code: RPItemCode) throws -> RPItem<RP> {
+    public func newItem(_ code: RPReferenceCode) throws -> RPItem<RP> {
         guard var item = items[code] else {
             throw RPCache.CacheError.notFound(code)
         }

--- a/Sources/RPTrunk/Data/Cache.swift
+++ b/Sources/RPTrunk/Data/Cache.swift
@@ -9,13 +9,15 @@ open class RPCache<RP: RPSpace> {
     public var abilities: [String: Ability<RP>] = [:]
     public var statusEffects: [String: StatusEffect<RP>] = [:]
     public var entities: [String: RPEntity<RP>] = [:]
-    
+    public var items: [String: RPItem<RP>] = [:]
+
     public init() {}
-    
+
     public func load(_ data: RPCacheJSON<RP.Stats>) throws {
         try loadStatusEffects(data.statusEffects ?? [:])
         try loadAbilities(data.abilities ?? [:])
         try loadEntities(data.entities ?? [:])
+        try loadItems(data.items ?? [:])
     }
 
     public func loadAbilities(_ abilities: [String: AbilityJSON<RP.Stats>]) throws {
@@ -59,6 +61,26 @@ open class RPCache<RP: RPSpace> {
             }
             self.entities[name] = entity
         }
+    }
+
+    public func loadItems(_ items: [String: ItemJSON<RP.Stats>]) throws {
+        try items.forEach { (name, data) in
+            let components: [Component<RP>] = try buildComponent(data)
+            let ability = try data.ability.map { try getAbility($0) }
+            let conditional = Conditional<RP>(data.conditional ?? "always")
+            var item = RPItem<RP>(components: components, ability: ability, conditional: conditional)
+            item.name = name
+            item.metadata = data.metadata
+            self.items[name] = item
+        }
+    }
+
+    public func newItem(_ name: String) throws -> RPItem<RP> {
+        guard var item = items[name] else {
+            throw RPCache.CacheError.notFound(name)
+        }
+        item.id = UUID().uuidString
+        return item
     }
 
     public func buildComponent<C: ComponentsContainerJSON>(_ component: C) throws -> [Component<RP>] where C.Stats == RP.Stats  {

--- a/Sources/RPTrunk/Data/CacheJSON.swift
+++ b/Sources/RPTrunk/Data/CacheJSON.swift
@@ -81,6 +81,7 @@ public struct ItemJSON<RP: RPSpace>: Codable, Equatable, ComponentsContainerJSON
     public var ability: String?
     public var conditional: String?
     public var cooldown: RPTimeIncrement?
+    public var maximumStack: Int?
 
     public var metadata: RP.ItemMetadata?
 }

--- a/Sources/RPTrunk/Data/CacheJSON.swift
+++ b/Sources/RPTrunk/Data/CacheJSON.swift
@@ -3,11 +3,13 @@ public struct RPCacheJSON<Stats: StatsType>: Codable, Equatable {
         case statusEffects = "Status Effects"
         case abilities = "Abilities"
         case entities = "Entities"
+        case items = "Items"
     }
-    
+
     public var abilities: [String: AbilityJSON<Stats>]?
     public var statusEffects: [String: StatusEffectJSON<Stats>]?
     public var entities: [String: EntityJSON<Stats>]?
+    public var items: [String: ItemJSON<Stats>]?
 }
 
 public protocol ComponentsContainerJSON {
@@ -58,6 +60,22 @@ public struct AbilityJSON<Stats: StatsType>: Codable, Equatable, ComponentsConta
     public var components: [String]?
 
     public let cooldown: RPTimeIncrement?
+
+    public var metadata: [String: String]?
+}
+
+public struct ItemJSON<Stats: StatsType>: Codable, Equatable, ComponentsContainerJSON {
+    public var stats: Stats?
+    public var cost: Stats?
+    public var requirements: Stats?
+    public var statusEffects: [String]?
+    public var target: String?
+    public var discharge: [String]?
+    public var components: [String]?
+
+    public var ability: String?
+    public var conditional: String?
+    public var cooldown: RPTimeIncrement?
 
     public var metadata: [String: String]?
 }

--- a/Sources/RPTrunk/Data/CacheJSON.swift
+++ b/Sources/RPTrunk/Data/CacheJSON.swift
@@ -24,6 +24,7 @@ public protocol ComponentsContainerJSON {
 }
 
 public struct StatusEffectJSON<RP: RPSpace>: Codable, Equatable, ComponentsContainerJSON {
+    public var displayName: String?
     public var stats: RP.Stats?
     public var cost: RP.Stats?
     public var requirements: RP.Stats?
@@ -41,7 +42,7 @@ public struct StatusEffectJSON<RP: RPSpace>: Codable, Equatable, ComponentsConta
 
 public struct EntityJSON<RP: RPSpace>: Codable, Equatable {
     public struct AbilityJSON: Codable, Equatable {
-        var name: String
+        var code: String
         var conditional: String
     }
     
@@ -53,6 +54,7 @@ public struct EntityJSON<RP: RPSpace>: Codable, Equatable {
 }
 
 public struct AbilityJSON<RP: RPSpace>: Codable, Equatable, ComponentsContainerJSON {
+    public var displayName: String?
     public var stats: RP.Stats?
     public var cost: RP.Stats?
     public var requirements: RP.Stats?
@@ -67,6 +69,7 @@ public struct AbilityJSON<RP: RPSpace>: Codable, Equatable, ComponentsContainerJ
 }
 
 public struct ItemJSON<RP: RPSpace>: Codable, Equatable, ComponentsContainerJSON {
+    public var displayName: String?
     public var stats: RP.Stats?
     public var cost: RP.Stats?
     public var requirements: RP.Stats?

--- a/Sources/RPTrunk/Data/CacheJSON.swift
+++ b/Sources/RPTrunk/Data/CacheJSON.swift
@@ -1,4 +1,4 @@
-public struct RPCacheJSON<Stats: StatsType>: Codable, Equatable {
+public struct RPCacheJSON<RP: RPSpace>: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case statusEffects = "Status Effects"
         case abilities = "Abilities"
@@ -6,10 +6,10 @@ public struct RPCacheJSON<Stats: StatsType>: Codable, Equatable {
         case items = "Items"
     }
 
-    public var abilities: [String: AbilityJSON<Stats>]?
-    public var statusEffects: [String: StatusEffectJSON<Stats>]?
-    public var entities: [String: EntityJSON<Stats>]?
-    public var items: [String: ItemJSON<Stats>]?
+    public var abilities: [String: AbilityJSON<RP>]?
+    public var statusEffects: [String: StatusEffectJSON<RP>]?
+    public var entities: [String: EntityJSON<RP>]?
+    public var items: [String: ItemJSON<RP>]?
 }
 
 public protocol ComponentsContainerJSON {
@@ -23,10 +23,10 @@ public protocol ComponentsContainerJSON {
     var components: [String]? { get }
 }
 
-public struct StatusEffectJSON<Stats: StatsType>: Codable, Equatable, ComponentsContainerJSON {
-    public var stats: Stats?
-    public var cost: Stats?
-    public var requirements: Stats?
+public struct StatusEffectJSON<RP: RPSpace>: Codable, Equatable, ComponentsContainerJSON {
+    public var stats: RP.Stats?
+    public var cost: RP.Stats?
+    public var requirements: RP.Stats?
     public var statusEffects: [String]?
     public var target: String?
     public var discharge: [String]?
@@ -39,21 +39,23 @@ public struct StatusEffectJSON<Stats: StatsType>: Codable, Equatable, Components
     public var period: RPTimeIncrement?
 }
 
-public struct EntityJSON<Stats: StatsType>: Codable, Equatable {
+public struct EntityJSON<RP: RPSpace>: Codable, Equatable {
     public struct AbilityJSON: Codable, Equatable {
         var name: String
         var conditional: String
     }
     
-    var displayName: String?
-    var stats: Stats? = .zero
-    var abilities: [AbilityJSON]?
+    public var displayName: String?
+    public var stats: RP.Stats? = .zero
+    public var abilities: [AbilityJSON]?
+    
+    public var metadata: RP.EntityMetadata?
 }
 
-public struct AbilityJSON<Stats: StatsType>: Codable, Equatable, ComponentsContainerJSON {
-    public var stats: Stats?
-    public var cost: Stats?
-    public var requirements: Stats?
+public struct AbilityJSON<RP: RPSpace>: Codable, Equatable, ComponentsContainerJSON {
+    public var stats: RP.Stats?
+    public var cost: RP.Stats?
+    public var requirements: RP.Stats?
     public var statusEffects: [String]?
     public var target: String?
     public var discharge: [String]?
@@ -61,13 +63,13 @@ public struct AbilityJSON<Stats: StatsType>: Codable, Equatable, ComponentsConta
 
     public let cooldown: RPTimeIncrement?
 
-    public var metadata: [String: String]?
+    public var metadata: RP.AbilityMetadata?
 }
 
-public struct ItemJSON<Stats: StatsType>: Codable, Equatable, ComponentsContainerJSON {
-    public var stats: Stats?
-    public var cost: Stats?
-    public var requirements: Stats?
+public struct ItemJSON<RP: RPSpace>: Codable, Equatable, ComponentsContainerJSON {
+    public var stats: RP.Stats?
+    public var cost: RP.Stats?
+    public var requirements: RP.Stats?
     public var statusEffects: [String]?
     public var target: String?
     public var discharge: [String]?
@@ -77,5 +79,5 @@ public struct ItemJSON<Stats: StatsType>: Codable, Equatable, ComponentsContaine
     public var conditional: String?
     public var cooldown: RPTimeIncrement?
 
-    public var metadata: [String: String]?
+    public var metadata: RP.ItemMetadata?
 }

--- a/Sources/RPTrunk/Data/CacheJSON.swift
+++ b/Sources/RPTrunk/Data/CacheJSON.swift
@@ -36,7 +36,7 @@ public struct StatusEffectJSON<RP: RPSpace>: Codable, Equatable, ComponentsConta
     public var duration: RPTimeIncrement?
     public var charges: Int?
     public var impairsAction: Bool? = false
-    /// Time (ms) between periodic pulses; omitted uses `StatusEffect.defaultPeriod`.
+    /// Time (ms) between periodic pulses; omitted uses `RPStatusEffect.defaultPeriod`.
     public var period: RPTimeIncrement?
 }
 

--- a/Sources/RPTrunk/Foundation/Abilities & Events/Ability.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/Ability.swift
@@ -4,7 +4,7 @@ public struct Ability<RP: RPSpace>: ComponentContainer, Codable {
     public var components: [Component<RP>]
     public var cooldown: RPTimeIncrement
     public var repeats: Int = 1
-    public var metadata: [String: String]?
+    public var metadata: RP.AbilityMetadata?
 
     public init(
         name: String,

--- a/Sources/RPTrunk/Foundation/Abilities & Events/Ability.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/Ability.swift
@@ -1,5 +1,5 @@
 
-public struct Ability<RP: RPSpace>: ComponentContainer, Codable {
+public struct RPAbility<RP: RPSpace>: ComponentContainer, Codable {
     public var code: RPReferenceCode
     public var displayName: String
     public var components: [Component<RP>]
@@ -20,24 +20,24 @@ public struct Ability<RP: RPSpace>: ComponentContainer, Codable {
     }
 }
 
-extension Ability: Equatable {}
-public func == <RP: RPSpace>(lhs: Ability<RP>, rhs: Ability<RP>) -> Bool {
+extension RPAbility: Equatable {}
+public func == <RP: RPSpace>(lhs: RPAbility<RP>, rhs: RPAbility<RP>) -> Bool {
     lhs.code == rhs.code && lhs.isEqualTo(rhs)
 }
 
 /**
     An ability, currently active on an entity
  */
-public struct ActiveAbility<RP: RPSpace>: Temporal, Codable {
+public struct RPActiveAbility<RP: RPSpace>: Temporal, Codable {
     public typealias Stats = RP.Stats
     public var currentTick: RPTimeIncrement = 0
     public var maximumTick: RPTimeIncrement { ability.cooldown }
 
     public var entityId: RPEntityId
-    public let ability: Ability<RP>
+    public let ability: RPAbility<RP>
     public let conditional: Conditional<RP>
 
-    public init(entityId: RPEntityId, ability: Ability<RP>, conditional: Conditional<RP>) {
+    public init(entityId: RPEntityId, ability: RPAbility<RP>, conditional: Conditional<RP>) {
         self.entityId = entityId
         self.ability = ability
         self.conditional = conditional
@@ -59,18 +59,18 @@ public struct ActiveAbility<RP: RPSpace>: Temporal, Codable {
         return (try? conditional.exec(e, rpSpace: rpSpace)) ?? false
     }
 
-    public func getPendingEvents(in rpSpace: RP) -> [Event<RP>] {
+    public func getPendingEvents(in rpSpace: RP) -> [RPEvent<RP>] {
         guard isCoolingDown() == false else {
             return []
         }
         return createEvents(in: rpSpace)
     }
 
-    fileprivate func createEvents(in rpSpace: RP) -> [Event<RP>] {
-        (0 ..< ability.repeats).map { _ in Event<RP>(initiator: entityId, ability: ability, rpSpace: rpSpace) }
+    fileprivate func createEvents(in rpSpace: RP) -> [RPEvent<RP>] {
+        (0 ..< ability.repeats).map { _ in RPEvent<RP>(initiator: entityId, ability: ability, rpSpace: rpSpace) }
     }
 
-    public mutating func tick(_ moment: Moment) {
+    public mutating func tick(_ moment: RPMoment) {
         if isCoolingDown() {
             currentTick += moment.delta
         }
@@ -81,7 +81,7 @@ public struct ActiveAbility<RP: RPSpace>: Temporal, Codable {
     }
 
     //TODO: revisit this function, was made pre-value type conversion
-    public func copyForEntity(_ entity: RPEntity<RP>) -> ActiveAbility {
-        ActiveAbility(entityId: entity.id, ability: ability, conditional: conditional)
+    public func copyForEntity(_ entity: RPEntity<RP>) -> RPActiveAbility {
+        RPActiveAbility(entityId: entity.id, ability: ability, conditional: conditional)
     }
 }

--- a/Sources/RPTrunk/Foundation/Abilities & Events/Ability.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/Ability.swift
@@ -1,17 +1,20 @@
 
 public struct Ability<RP: RPSpace>: ComponentContainer, Codable {
-    public var name: String
+    public var code: RPReferenceCode
+    public var displayName: String
     public var components: [Component<RP>]
     public var cooldown: RPTimeIncrement
     public var repeats: Int = 1
     public var metadata: RP.AbilityMetadata?
 
     public init(
-        name: String,
+        code: RPReferenceCode,
+        displayName: String? = nil,
         components: [Component<RP>] = [],
         cooldown: RPTimeIncrement? = nil
     ) {
-        self.name = name
+        self.code = code
+        self.displayName = displayName ?? code
         self.components = components
         self.cooldown = cooldown ?? 0
     }
@@ -19,7 +22,7 @@ public struct Ability<RP: RPSpace>: ComponentContainer, Codable {
 
 extension Ability: Equatable {}
 public func == <RP: RPSpace>(lhs: Ability<RP>, rhs: Ability<RP>) -> Bool {
-    lhs.name == rhs.name && lhs.isEqualTo(rhs)
+    lhs.code == rhs.code && lhs.isEqualTo(rhs)
 }
 
 /**

--- a/Sources/RPTrunk/Foundation/Abilities & Events/Event.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/Event.swift
@@ -1,10 +1,12 @@
 public struct EventResult<RP: RPSpace>: Equatable, Codable {
     public let event: Event<RP>
     public let effects: [ConflictResult<RP>]
+    public let itemTransfers: [ItemTransfer]
 
-    init(_ event: Event<RP>, _ effects: [ConflictResult<RP>]) {
+    init(_ event: Event<RP>, _ effects: [ConflictResult<RP>], _ itemTransfers: [ItemTransfer] = []) {
         self.event = event
         self.effects = effects
+        self.itemTransfers = itemTransfers
     }
 }
 
@@ -81,7 +83,7 @@ public struct Event<RP: RPSpace>: Equatable, Codable {
         return results
     }
 
-    func applyResults(_ results: [ConflictResult<RP>], in rpSpace: inout RP) {
+    func applyResults(_ results: [ConflictResult<RP>], in rpSpace: inout RP) -> [ItemTransfer] {
         results.forEach { result -> Void in
             let newStats = (rpSpace.entityById(result.entity)?.currentStats ?? .zero) + result.change
             rpSpace.modifyEntity(id: result.entity, perform: {
@@ -89,13 +91,14 @@ public struct Event<RP: RPSpace>: Equatable, Codable {
             })
         }
         applyStatusEffectChanges(to: targets, in: &rpSpace)
-        applyItemExchange(in: &rpSpace)
-        
+        let itemTransfers = applyItemExchange(in: &rpSpace)
+
         if case let .periodicEffect(name) = category, let initiator = initiator {
             rpSpace.modifyEntity(id: initiator) { entity, space in
                 entity.statusEffects[name]?.incrementTick()
             }
         }
+        return itemTransfers
     }
 
     private func applyStatusEffectChanges(to targets: Set<RPEntityId>, in rpSpace: inout RP) {
@@ -116,43 +119,25 @@ public struct Event<RP: RPSpace>: Equatable, Codable {
             }
     }
 
-    func applyItemExchange(in rpSpace: inout RP) {
-        guard let exchange = ability.itemExchange else { return }
-        
-        if let initiator = initiator, let entity = rpSpace.entityById(initiator) {
-            if exchange.requiresInitiatorOwnItem {
-                if entity.inventory.contains(where: { $0 == exchange.item }) == false {
-                    // should not exchange since initiator does not currently own the item
-                    return
-                }
-                if var newItemState = rpSpace.itemById(exchange.item) {
-                    newItemState.amount -= 1
-                    if newItemState.amount <= 0 {
-                        rpSpace.modifyEntity(id: initiator) { e, _ in e.inventory.removeAll(where: { $0 == exchange.item }) }
-                    }
-                    rpSpace.modifyItem(id: exchange.item, perform: { i, _ in i = newItemState })
-                }
-            }
-        }
-    
-        switch exchange.exchangeType {
-        case .target:
-            if let targetId = targets.first {
-                rpSpace.modifyEntity(id: targetId) { e, _ in e.inventory.append(exchange.item) }
-            }
-        case .targetTeam:
-            if let teamId = targets.first.flatMap(rpSpace.entityById)?.teamId {
-                rpSpace.modifyTeam(id: teamId) { t, _ in t.inventory.append(exchange.item) }
-            } else if let targetId = targets.first {
-                rpSpace.modifyEntity(id: targetId) { e, _ in e.inventory.append(exchange.item) }
-            }
+    func applyItemExchange(in rpSpace: inout RP) -> [ItemTransfer] {
+        guard let exchange = ability.itemExchange,
+              let initiator = initiator,
+              let recipient = targets.first
+        else { return [] }
+
+        switch exchange.kind {
+        case .transfer(let itemId):
+            guard rpSpace.itemById(itemId)?.entity == initiator else { return [] }
+            return rpSpace.transferItem(id: itemId, to: recipient)
+        case .transferAll:
+            return rpSpace.transferAllItems(from: initiator, to: recipient)
         }
     }
 
     public func execute(in rpSpace: inout RP) -> EventResult<RP> {
         let results = getResults(in: rpSpace)
-        applyResults(results, in: &rpSpace)
-        let eventResult = EventResult<RP>(self, results)
+        let itemTransfers = applyResults(results, in: &rpSpace)
+        let eventResult = EventResult<RP>(self, results, itemTransfers)
         rpSpace.applyThreatChanges(
             RP.resolveThreatChanges(for: eventResult, in: rpSpace)
         )

--- a/Sources/RPTrunk/Foundation/Abilities & Events/Event.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/Event.swift
@@ -163,7 +163,7 @@ public struct Event<RP: RPSpace>: Equatable, Codable {
         guard let initiator = initiator else { return }
         rpSpace.modifyEntity(id: initiator) { e, _ in
             e.resetCooldown()
-            e.resetAbility(byName: ability.name)
+            e.resetAbility(byName: ability.code)
         }
     }
 }

--- a/Sources/RPTrunk/Foundation/Abilities & Events/Event.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/Event.swift
@@ -1,16 +1,16 @@
-public struct EventResult<RP: RPSpace>: Equatable, Codable {
-    public let event: Event<RP>
+public struct RPEventResult<RP: RPSpace>: Equatable, Codable {
+    public let event: RPEvent<RP>
     public let effects: [ConflictResult<RP>]
-    public let itemTransfers: [ItemTransfer]
+    public let itemTransfers: [RPItemTransfer]
 
-    init(_ event: Event<RP>, _ effects: [ConflictResult<RP>], _ itemTransfers: [ItemTransfer] = []) {
+    init(_ event: RPEvent<RP>, _ effects: [ConflictResult<RP>], _ itemTransfers: [RPItemTransfer] = []) {
         self.event = event
         self.effects = effects
         self.itemTransfers = itemTransfers
     }
 }
 
-public struct Event<RP: RPSpace>: Equatable, Codable {
+public struct RPEvent<RP: RPSpace>: Equatable, Codable {
     public typealias Stats = RP.Stats
     public enum Category: Equatable, Codable {
         case standardConflict
@@ -20,14 +20,14 @@ public struct Event<RP: RPSpace>: Equatable, Codable {
 
     public var id = UUID().uuidString
     public let category: Category
-    public let ability: Ability<RP>
+    public let ability: RPAbility<RP>
     public let targets: Set<RPEntityId>
     public let initiator: RPEntityId?
 
     public init(
         category: Category = .standardConflict,
         initiator: RPEntityId,
-        ability: Ability<RP>,
+        ability: RPAbility<RP>,
         targets: Set<RPEntityId>? = nil,
         rpSpace: RP
     ) {
@@ -39,7 +39,7 @@ public struct Event<RP: RPSpace>: Equatable, Codable {
     
     public init(
         category: Category = .standardConflict,
-        ability: Ability<RP>,
+        ability: RPAbility<RP>,
         targets: Set<RPEntityId>
     ) {
         self.category = category
@@ -83,7 +83,7 @@ public struct Event<RP: RPSpace>: Equatable, Codable {
         return results
     }
 
-    func applyResults(_ results: [ConflictResult<RP>], in rpSpace: inout RP) -> [ItemTransfer] {
+    func applyResults(_ results: [ConflictResult<RP>], in rpSpace: inout RP) -> [RPItemTransfer] {
         results.forEach { result -> Void in
             let newStats = (rpSpace.entityById(result.entity)?.currentStats ?? .zero) + result.change
             rpSpace.modifyEntity(id: result.entity, perform: {
@@ -119,7 +119,7 @@ public struct Event<RP: RPSpace>: Equatable, Codable {
             }
     }
 
-    func applyItemExchange(in rpSpace: inout RP) -> [ItemTransfer] {
+    func applyItemExchange(in rpSpace: inout RP) -> [RPItemTransfer] {
         guard let exchange = ability.itemExchange,
               let initiator = initiator,
               let recipient = targets.first
@@ -127,17 +127,16 @@ public struct Event<RP: RPSpace>: Equatable, Codable {
 
         switch exchange.kind {
         case .transfer(let itemId):
-            guard rpSpace.itemById(itemId)?.entity == initiator else { return [] }
-            return rpSpace.transferItem(id: itemId, to: recipient)
+            return rpSpace.transferItem(id: itemId, from: initiator, to: recipient)
         case .transferAll:
             return rpSpace.transferAllItems(from: initiator, to: recipient)
         }
     }
 
-    public func execute(in rpSpace: inout RP) -> EventResult<RP> {
+    public func execute(in rpSpace: inout RP) -> RPEventResult<RP> {
         let results = getResults(in: rpSpace)
         let itemTransfers = applyResults(results, in: &rpSpace)
-        let eventResult = EventResult<RP>(self, results, itemTransfers)
+        let eventResult = RPEventResult<RP>(self, results, itemTransfers)
         rpSpace.applyThreatChanges(
             RP.resolveThreatChanges(for: eventResult, in: rpSpace)
         )

--- a/Sources/RPTrunk/Foundation/Abilities & Events/ItemExchange.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/ItemExchange.swift
@@ -6,7 +6,7 @@
      - exchange item between entities (trade, steal, drop)
      - use item, to initiate an ability
  */
-public struct ItemExchange: Codable, Equatable {
+public struct RPItemExchange: Codable, Equatable {
     public enum Kind: Codable, Equatable {
         case transfer(RPItemId)
         case transferAll

--- a/Sources/RPTrunk/Foundation/Abilities & Events/ItemExchange.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/ItemExchange.swift
@@ -7,25 +7,14 @@
      - use item, to initiate an ability
  */
 public struct ItemExchange: Codable, Equatable {
-    public enum ExchangeType: String, Codable, Equatable {
-        case target
-        case targetTeam
+    public enum Kind: Codable, Equatable {
+        case transfer(RPItemId)
+        case transferAll
     }
 
-    public let exchangeType: ExchangeType
-    public let requiresInitiatorOwnItem: Bool
-    public let removesItemFromInitiator: Bool
-    public let item: RPItemId
-    
-    public init(
-        exchangeType: ItemExchange.ExchangeType,
-        requiresInitiatorOwnItem: Bool,
-        removesItemFromInitiator: Bool,
-        item: RPItemId
-    ) {
-        self.exchangeType = exchangeType
-        self.requiresInitiatorOwnItem = requiresInitiatorOwnItem
-        self.removesItemFromInitiator = removesItemFromInitiator
-        self.item = item
+    public let kind: Kind
+
+    public init(kind: Kind) {
+        self.kind = kind
     }
 }

--- a/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
@@ -1,5 +1,6 @@
 public struct RPItem<RP: RPSpace>: Temporal, ComponentContainer, Codable, Equatable {
     public var id: RPItemId = UUID().uuidString
+    public var cacheId: RPItemCacheId?
     public var name: String
     public var amount: Int = 1
 
@@ -10,7 +11,7 @@ public struct RPItem<RP: RPSpace>: Temporal, ComponentContainer, Codable, Equata
     public var components: [Component<RP>]
     public var ability: Ability<RP>?
     public var conditional: Conditional<RP>
-    public var metadata: [String: String]?
+    public var metadata: RP.ItemMetadata?
 
     public init(
         components: [Component<RP>] = [],

--- a/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
@@ -10,6 +10,7 @@ public struct RPItem<RP: RPSpace>: Temporal, ComponentContainer, Codable, Equata
     public var components: [Component<RP>]
     public var ability: Ability<RP>?
     public var conditional: Conditional<RP>
+    public var metadata: [String: String]?
 
     public init(
         components: [Component<RP>] = [],

--- a/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
@@ -1,6 +1,6 @@
 public struct RPItem<RP: RPSpace>: Temporal, ComponentContainer, Codable, Equatable {
     public var id: RPItemId = UUID().uuidString
-    public var cacheId: RPItemCacheId?
+    public var code: RPItemCode?
     public var name: String
     public var amount: Int = 1
 

--- a/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
@@ -1,7 +1,7 @@
 public struct RPItem<RP: RPSpace>: Temporal, ComponentContainer, Codable, Equatable {
     public var id: RPItemId = UUID().uuidString
-    public var code: RPItemCode?
-    public var name: String
+    public var code: RPReferenceCode?
+    public var displayName: String
     public var amount: Int = 1
 
     public var currentTick: RPTimeIncrement = 0
@@ -18,7 +18,7 @@ public struct RPItem<RP: RPSpace>: Temporal, ComponentContainer, Codable, Equata
         ability: Ability<RP>? = nil,
         conditional: Conditional<RP> = .always
     ) {
-        name = "Untitled Item"
+        displayName = "Untitled Item"
         self.components = components
         self.ability = ability
         self.conditional = conditional

--- a/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
@@ -1,27 +1,59 @@
-public struct RPItem<RP: RPSpace>: Temporal, ComponentContainer, Codable, Equatable {
-    public var id: RPItemId = UUID().uuidString
-    public var code: RPReferenceCode?
+public struct RPItem<RP: RPSpace>: ComponentContainer, Codable, Equatable {
+    public var code: RPReferenceCode
     public var displayName: String
-    public var amount: Int = 1
-
-    public var currentTick: RPTimeIncrement = 0
-    public var maximumTick: RPTimeIncrement { ability?.cooldown ?? 0 }
-
-    public var entity: RPEntityId?
+    public var maximumStack: Int?
     public var components: [Component<RP>]
     public var ability: Ability<RP>?
     public var conditional: Conditional<RP>
     public var metadata: RP.ItemMetadata?
 
     public init(
+        code: RPReferenceCode,
+        displayName: String? = nil,
+        maximumStack: Int? = nil,
         components: [Component<RP>] = [],
         ability: Ability<RP>? = nil,
         conditional: Conditional<RP> = .always
     ) {
-        displayName = "Untitled Item"
+        self.code = code
+        self.displayName = displayName ?? code
+        self.maximumStack = maximumStack
         self.components = components
         self.ability = ability
         self.conditional = conditional
+    }
+}
+
+public struct RPActiveItem<RP: RPSpace>: Temporal, Codable, Equatable {
+    public var id: RPItemId = UUID().uuidString
+    public var item: RPItem<RP>
+    public var amount: Int
+    public var entity: RPEntityId?
+
+    public var currentTick: RPTimeIncrement = 0
+    public var maximumTick: RPTimeIncrement { item.ability?.cooldown ?? 0 }
+
+    public var code: RPReferenceCode { item.code }
+    public var displayName: String { item.displayName }
+    public var stats: RP.Stats { item.stats }
+
+    public init(
+        item: RPItem<RP>,
+        amount: Int = 1,
+        entity: RPEntityId? = nil
+    ) {
+        self.item = item
+        self.amount = amount
+        self.entity = entity
+    }
+
+    public func hasCapacity(for additionalAmount: Int) -> Bool {
+        guard let maximumStack = item.maximumStack else { return true }
+        return amount + additionalAmount <= maximumStack
+    }
+
+    public var remainingCapacity: Int? {
+        item.maximumStack.map { max(0, $0 - amount) }
     }
 
     public func canExecute(in rpSpace: RP) -> Bool {
@@ -31,13 +63,13 @@ public struct RPItem<RP: RPSpace>: Temporal, ComponentContainer, Codable, Equata
 
         guard let entityId = entity,
               let e = rpSpace.entityById(entityId),
-              let a = ability,
+              let a = item.ability,
               a.cost < e.currentStats
         else {
             return false
         }
 
-        return (try? conditional.exec(e, rpSpace: rpSpace)) ?? false
+        return (try? item.conditional.exec(e, rpSpace: rpSpace)) ?? false
     }
 
     public func getPendingEvents(in rpSpace: RP) -> [Event<RP>] {
@@ -48,8 +80,8 @@ public struct RPItem<RP: RPSpace>: Temporal, ComponentContainer, Codable, Equata
     }
 
     fileprivate func createEvents(in rpSpace: RP) -> [Event<RP>] {
-        guard let ability = self.ability,
-              let entityId = self.entity
+        guard let ability = item.ability,
+              let entityId = entity
         else {
             return []
         }

--- a/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
+++ b/Sources/RPTrunk/Foundation/Abilities & Events/RPItem.swift
@@ -3,7 +3,7 @@ public struct RPItem<RP: RPSpace>: ComponentContainer, Codable, Equatable {
     public var displayName: String
     public var maximumStack: Int?
     public var components: [Component<RP>]
-    public var ability: Ability<RP>?
+    public var ability: RPAbility<RP>?
     public var conditional: Conditional<RP>
     public var metadata: RP.ItemMetadata?
 
@@ -12,7 +12,7 @@ public struct RPItem<RP: RPSpace>: ComponentContainer, Codable, Equatable {
         displayName: String? = nil,
         maximumStack: Int? = nil,
         components: [Component<RP>] = [],
-        ability: Ability<RP>? = nil,
+        ability: RPAbility<RP>? = nil,
         conditional: Conditional<RP> = .always
     ) {
         self.code = code
@@ -28,7 +28,6 @@ public struct RPActiveItem<RP: RPSpace>: Temporal, Codable, Equatable {
     public var id: RPItemId = UUID().uuidString
     public var item: RPItem<RP>
     public var amount: Int
-    public var entity: RPEntityId?
 
     public var currentTick: RPTimeIncrement = 0
     public var maximumTick: RPTimeIncrement { item.ability?.cooldown ?? 0 }
@@ -39,12 +38,10 @@ public struct RPActiveItem<RP: RPSpace>: Temporal, Codable, Equatable {
 
     public init(
         item: RPItem<RP>,
-        amount: Int = 1,
-        entity: RPEntityId? = nil
+        amount: Int = 1
     ) {
         self.item = item
         self.amount = amount
-        self.entity = entity
     }
 
     public func hasCapacity(for additionalAmount: Int) -> Bool {
@@ -56,13 +53,12 @@ public struct RPActiveItem<RP: RPSpace>: Temporal, Codable, Equatable {
         item.maximumStack.map { max(0, $0 - amount) }
     }
 
-    public func canExecute(in rpSpace: RP) -> Bool {
+    public func canExecute(by entityId: RPEntityId, in rpSpace: RP) -> Bool {
         guard isCoolingDown() == false else {
             return false
         }
 
-        guard let entityId = entity,
-              let e = rpSpace.entityById(entityId),
+        guard let e = rpSpace.entityById(entityId),
               let a = item.ability,
               a.cost < e.currentStats
         else {
@@ -72,25 +68,20 @@ public struct RPActiveItem<RP: RPSpace>: Temporal, Codable, Equatable {
         return (try? item.conditional.exec(e, rpSpace: rpSpace)) ?? false
     }
 
-    public func getPendingEvents(in rpSpace: RP) -> [Event<RP>] {
-        guard isCoolingDown() == false else {
-            return []
-        }
-        return createEvents(in: rpSpace)
+    public func getPendingEvents(in rpSpace: RP) -> [RPEvent<RP>] {
+        []
     }
 
-    fileprivate func createEvents(in rpSpace: RP) -> [Event<RP>] {
-        guard let ability = item.ability,
-              let entityId = entity
-        else {
+    public func getPendingEvents(by entityId: RPEntityId, in rpSpace: RP) -> [RPEvent<RP>] {
+        guard isCoolingDown() == false, let ability = item.ability else {
             return []
         }
         return (0 ..< ability.repeats).map { _ in
-            Event(initiator: entityId, ability: ability, rpSpace: rpSpace)
+            RPEvent(initiator: entityId, ability: ability, rpSpace: rpSpace)
         }
     }
 
-    public mutating func tick(_ moment: Moment) {
+    public mutating func tick(_ moment: RPMoment) {
         if isCoolingDown() {
             currentTick += moment.delta
         }

--- a/Sources/RPTrunk/Foundation/Component.swift
+++ b/Sources/RPTrunk/Foundation/Component.swift
@@ -8,10 +8,10 @@ public struct Component<RP: RPSpace>: Codable, Equatable {
     public var stats: Stats?
     public var cost: Stats?
     public var requirements: Stats?
-    public var targeting: Targeting<RP>?
-    public var statusEffects: [StatusEffect<RP>]?
+    public var targeting: RPTargeting<RP>?
+    public var statusEffects: [RPStatusEffect<RP>]?
     public var dischargedStatusEffects: [String]?
-    public var itemExchange: ItemExchange?
+    public var itemExchange: RPItemExchange?
 
     public init(stats: Stats) {
         self.stats = stats
@@ -25,11 +25,11 @@ public struct Component<RP: RPSpace>: Codable, Equatable {
         self.requirements = requirements
     }
 
-    public init(targetType: Targeting<RP>) {
+    public init(targetType: RPTargeting<RP>) {
         targeting = targetType
     }
 
-    public init(statusEffects: [StatusEffect<RP>]) {
+    public init(statusEffects: [RPStatusEffect<RP>]) {
         self.statusEffects = statusEffects
     }
 
@@ -37,7 +37,7 @@ public struct Component<RP: RPSpace>: Codable, Equatable {
         self.dischargedStatusEffects = dischargedStatusEffects
     }
 
-    public init(itemExchange: ItemExchange) {
+    public init(itemExchange: RPItemExchange) {
         self.itemExchange = itemExchange
     }
 
@@ -56,8 +56,8 @@ public struct Component<RP: RPSpace>: Codable, Equatable {
     public func getStats() -> Stats? { stats }
     public func getCost() -> Stats? { cost }
     public func getRequirements() -> Stats? { requirements }
-    public func getTargeting() -> Targeting<RP>? { targeting }
-    public func getStatusEffects() -> [StatusEffect<RP>] { statusEffects ?? [] }
+    public func getTargeting() -> RPTargeting<RP>? { targeting }
+    public func getStatusEffects() -> [RPStatusEffect<RP>] { statusEffects ?? [] }
     public func getDischargedStatusEffects() -> [String] { dischargedStatusEffects ?? [] }
-    public func getItemExchange() -> ItemExchange? { itemExchange }
+    public func getItemExchange() -> RPItemExchange? { itemExchange }
 }

--- a/Sources/RPTrunk/Foundation/ComponentContainer.swift
+++ b/Sources/RPTrunk/Foundation/ComponentContainer.swift
@@ -23,16 +23,16 @@ public extension ComponentContainer {
             .reduce(.zero, +)
     }
 
-    var targeting: Targeting<RP> {
+    var targeting: RPTargeting<RP> {
         for component in components {
             if let t = component.getTargeting() {
                 return t
             }
         }
-        return Targeting(.singleEnemy, .always)
+        return RPTargeting(.singleEnemy, .always)
     }
 
-    var statusEffects: [StatusEffect<RP>] {
+    var statusEffects: [RPStatusEffect<RP>] {
         components
             .flatMap { $0.getStatusEffects() }
     }
@@ -42,7 +42,7 @@ public extension ComponentContainer {
             .flatMap { $0.getDischargedStatusEffects() }
     }
 
-    var itemExchange: ItemExchange? {
+    var itemExchange: RPItemExchange? {
         for component in components {
             if let exchange = component.getItemExchange() {
                 return exchange

--- a/Sources/RPTrunk/Foundation/Equipment.swift
+++ b/Sources/RPTrunk/Foundation/Equipment.swift
@@ -5,5 +5,6 @@ public protocol InventoryManager {
 }
 
 public struct Body<RP: RPSpace>: Codable {
-    var wornItems: [RPItemId] = []
+    public var wornItems: [RPItemId] = []
+    public init() {}
 }

--- a/Sources/RPTrunk/Foundation/Equipment.swift
+++ b/Sources/RPTrunk/Foundation/Equipment.swift
@@ -1,10 +1,10 @@
 
 public protocol InventoryManager {
     associatedtype RP: RPSpace
-    var inventory: [RPItemId] { get set }
+    var inventory: [RPActiveItem<RP>] { get set }
 }
 
-public struct Body<RP: RPSpace>: Codable {
-    public var wornItems: [RPItemId] = []
+public struct Body<RP: RPSpace>: Codable, Equatable {
+    public var wornItems: [RPActiveItem<RP>] = []
     public init() {}
 }

--- a/Sources/RPTrunk/Foundation/RPEntity.swift
+++ b/Sources/RPTrunk/Foundation/RPEntity.swift
@@ -22,6 +22,7 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
     public var currentStats: Stats = .zero
     public var body = Body<RP>()
     public var inventory: [RPItemId] = []
+    public var metadata: RP.EntityMetadata?
 
     public internal(set) var executableAbilities: [String: ActiveAbility<RP>] = [:]
     public internal(set) var passiveAbilities: [String: ActiveAbility<RP>] = [:]

--- a/Sources/RPTrunk/Foundation/RPEntity.swift
+++ b/Sources/RPTrunk/Foundation/RPEntity.swift
@@ -22,12 +22,12 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
     public var baseStats: Stats = .zero
     public var currentStats: Stats = .zero
     public var body = Body<RP>()
-    public var inventory: [RPItemId] = []
+    public var inventory: [RPActiveItem<RP>] = []
     public var metadata: RP.EntityMetadata?
 
-    public internal(set) var executableAbilities: [String: ActiveAbility<RP>] = [:]
-    public internal(set) var passiveAbilities: [String: ActiveAbility<RP>] = [:]
-    public internal(set) var statusEffects: [String: ActiveStatusEffect<RP>] = [:]
+    public internal(set) var executableAbilities: [String: RPActiveAbility<RP>] = [:]
+    public internal(set) var passiveAbilities: [String: RPActiveAbility<RP>] = [:]
+    public internal(set) var statusEffects: [String: RPActiveStatusEffect<RP>] = [:]
 
     public var targets: Set<RPEntityId> = []
 
@@ -60,11 +60,9 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
     
     public func getTotalStats(in rpSpace: RP) -> Stats {
         var totalStats = self.baseStats
-        body.wornItems
-            .compactMap { rpSpace.itemById($0) }
-            .forEach { item in
-                totalStats = totalStats + item.stats
-            }
+        body.wornItems.forEach { item in
+            totalStats = totalStats + item.stats
+        }
         return totalStats
     }
 
@@ -77,7 +75,7 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
         currentStats = Stats(dict: newCurrentStats)
     }
 
-    public func usableAbilities(in rpSpace: RP) -> [ActiveAbility<RP>] {
+    public func usableAbilities(in rpSpace: RP) -> [RPActiveAbility<RP>] {
         guard !isCoolingDown() else {
             return []
         }
@@ -142,22 +140,22 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
         threat.removeValue(forKey: id)
     }
 
-    public mutating func addExecutableAbility(_ ability: Ability<RP>, conditional: Conditional<RP>) {
-        let activeAbility = ActiveAbility<RP>(entityId: id, ability: ability, conditional: conditional)
+    public mutating func addExecutableAbility(_ ability: RPAbility<RP>, conditional: Conditional<RP>) {
+        let activeAbility = RPActiveAbility<RP>(entityId: id, ability: ability, conditional: conditional)
         executableAbilities[ability.code] = activeAbility
     }
 
-    public mutating func addPassiveAbility(_ ability: Ability<RP>, conditional: Conditional<RP>) {
-        let activeAbility = ActiveAbility<RP>(entityId: id, ability: ability, conditional: conditional)
+    public mutating func addPassiveAbility(_ ability: RPAbility<RP>, conditional: Conditional<RP>) {
+        let activeAbility = RPActiveAbility<RP>(entityId: id, ability: ability, conditional: conditional)
         passiveAbilities[ability.code] = activeAbility
     }
 
-    public mutating func applyStatusEffect(_ statusEffect: StatusEffect<RP>) {
+    public mutating func applyStatusEffect(_ statusEffect: RPStatusEffect<RP>) {
         if statusEffects[statusEffect.code] != nil {
             // TODO: Handle stackability of status effects rather than just resetting
             statusEffects[statusEffect.code]?.resetCooldown()
         } else {
-            statusEffects[statusEffect.code] = ActiveStatusEffect<RP>(entityId: id, statusEffect: statusEffect)
+            statusEffects[statusEffect.code] = RPActiveStatusEffect<RP>(entityId: id, statusEffect: statusEffect)
         }
     }
 
@@ -184,7 +182,7 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
         executableAbilities[name]?.resetCooldown()
     }
 
-    public mutating func tick(_ moment: Moment) {
+    public mutating func tick(_ moment: RPMoment) {
         if currentTick < maximumTick {
             currentTick += moment.delta
         }
@@ -207,15 +205,15 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
         }
     }
 
-    public func getPendingEvents(in rpSpace: RP) -> [Event<RP>] {
+    public func getPendingEvents(in rpSpace: RP) -> [RPEvent<RP>] {
         getPendingPassiveEvents(in: rpSpace) + getPendingExecutableEvents(in: rpSpace)
     }
 
-    func getPendingStatusEffectEvents(in rpSpace: RP) -> [Event<RP>] {
+    func getPendingStatusEffectEvents(in rpSpace: RP) -> [RPEvent<RP>] {
         statusEffects.values.flatMap { $0.getPendingEvents(in: rpSpace) }
     }
 
-    public func getPendingExecutableEvents(in rpSpace: RP) -> [Event<RP>] {
+    public func getPendingExecutableEvents(in rpSpace: RP) -> [RPEvent<RP>] {
         guard !isCoolingDown(), canPerformEvents() else {
             return []
         }
@@ -234,8 +232,8 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
         return abilityEvents
     }
 
-    public func getPendingPassiveEvents(in rpSpace: RP) -> [Event<RP>] {
-        var abilityEvents = [Event<RP>]()
+    public func getPendingPassiveEvents(in rpSpace: RP) -> [RPEvent<RP>] {
+        var abilityEvents = [RPEvent<RP>]()
 
         for activeAbility in passiveAbilities.values where activeAbility.canExecute(in: rpSpace) {
             abilityEvents += activeAbility.getPendingEvents(in: rpSpace)

--- a/Sources/RPTrunk/Foundation/RPEntity.swift
+++ b/Sources/RPTrunk/Foundation/RPEntity.swift
@@ -11,6 +11,7 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
         }
     }
     
+    public var code: RPReferenceCode?
     public var displayName: String = "???"
 
     public var teamId: RPTeamId?
@@ -143,27 +144,27 @@ public struct RPEntity<RP: RPSpace>: Temporal, InventoryManager, Codable {
 
     public mutating func addExecutableAbility(_ ability: Ability<RP>, conditional: Conditional<RP>) {
         let activeAbility = ActiveAbility<RP>(entityId: id, ability: ability, conditional: conditional)
-        executableAbilities[ability.name] = activeAbility
+        executableAbilities[ability.code] = activeAbility
     }
 
     public mutating func addPassiveAbility(_ ability: Ability<RP>, conditional: Conditional<RP>) {
         let activeAbility = ActiveAbility<RP>(entityId: id, ability: ability, conditional: conditional)
-        passiveAbilities[ability.name] = activeAbility
+        passiveAbilities[ability.code] = activeAbility
     }
 
     public mutating func applyStatusEffect(_ statusEffect: StatusEffect<RP>) {
-        if statusEffects[statusEffect.name] != nil {
+        if statusEffects[statusEffect.code] != nil {
             // TODO: Handle stackability of status effects rather than just resetting
-            statusEffects[statusEffect.name]?.resetCooldown()
+            statusEffects[statusEffect.code]?.resetCooldown()
         } else {
-            statusEffects[statusEffect.name] = ActiveStatusEffect<RP>(entityId: id, statusEffect: statusEffect)
+            statusEffects[statusEffect.code] = ActiveStatusEffect<RP>(entityId: id, statusEffect: statusEffect)
         }
     }
 
     public mutating func dischargeStatusEffect(_ label: String) {
         let relevantEffectNames = statusEffects.values
             .filter { $0.tags.contains(label) }
-            .map(\.name)
+            .map(\.code)
 
         relevantEffectNames
             .forEach { self.statusEffects[$0]?.expendCharge() }

--- a/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
+++ b/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
@@ -1,8 +1,8 @@
 public typealias RPEntityId = String
 public typealias RPTeamId = String
 public typealias RPItemId = String
-public typealias RPItemCode = String
 public typealias RPEventId = String
+public typealias RPReferenceCode = String
 
 public protocol RPMetadata: Codable & Equatable {}
 public struct EmptyMetadataDictionary: RPMetadata, Sendable {
@@ -211,7 +211,7 @@ extension RPSpace {
         let targeting = Component<Self>(targetType: Targeting(.oneself, .always))
 
         let collect = Ability<Self>(
-            name: "",
+            code: "",
             components: [
                 exchange,
                 targeting,

--- a/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
+++ b/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
@@ -1,7 +1,7 @@
 public typealias RPEntityId = String
 public typealias RPTeamId = String
 public typealias RPItemId = String
-public typealias RPItemCacheId = String
+public typealias RPItemCode = String
 public typealias RPEventId = String
 
 public protocol RPMetadata: Codable & Equatable {}

--- a/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
+++ b/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
@@ -24,8 +24,7 @@ public protocol RPSpace: Codable {
     associatedtype TeamSequence: Sequence where TeamSequence.Element == RPTeamId
 
     typealias ActiveItem = RPActiveItem<Self>
-    associatedtype ItemSequence: Sequence where ItemSequence.Element == RPItemId
-    
+
     static var statTypes: Set<String> { get }
 
     static func createDefaultEntity(cache: RPCache<Self>) -> Entity
@@ -33,7 +32,7 @@ public protocol RPSpace: Codable {
     /// How any interaction between to entities in resolves.
     ///  Events contain all the data necessary to calculate an end result
     static func resolveConflict(
-        _ event: Event<Self>,
+        _ event: RPEvent<Self>,
         in rpSpace: Self,
         target: RPEntityId,
         conflict: Stats
@@ -43,29 +42,24 @@ public protocol RPSpace: Codable {
     /// requirement so conformances can customize it; the default
     /// implementation produces no threat, leaving the system dormant.
     static func resolveThreatChanges(
-        for eventResult: EventResult<Self>,
+        for eventResult: RPEventResult<Self>,
         in rpSpace: Self
     ) -> [ThreatChange]
 
     func entityById(_ id: RPEntityId) -> Entity?
     func teamById(_ id: RPTeamId) -> Team?
-    func itemById(_ id: RPItemId) -> ActiveItem?
 
     func allEntities() -> EntitySequence
     func allTeams() -> TeamSequence
-    func allItems() -> ItemSequence
-    func allPendingGameMasterEvents() -> [Event<Self>]
+    func allPendingGameMasterEvents() -> [RPEvent<Self>]
 
     mutating func addEntity(_ entity: Entity)
     mutating func setTeams(_ newTeams: [Team])
-    mutating func addItem(_ item: ActiveItem)
-    mutating func removeItem(id: RPItemId)
-    mutating func queueGameMasterEvent(_ event: Event<Self>)
+    mutating func queueGameMasterEvent(_ event: RPEvent<Self>)
     mutating func removeGameMasterEvent(id: RPEventId)
 
     mutating func modifyEntity(id: RPEntityId, perform: (inout Entity, Self) -> Void)
     mutating func modifyTeam(id: RPTeamId, perform: (inout Team, Self) -> Void)
-    mutating func modifyItem(id: RPItemId, perform: (inout ActiveItem, Self) -> Void)
 
 }
 
@@ -125,7 +119,7 @@ public extension RPSpace {
 }
 
 extension RPSpace {
-    public mutating func tick(_ moment: Moment) {
+    public mutating func tick(_ moment: RPMoment) {
         allTeams()
             .compactMap(teamById)
             .flatMap(\.entities)
@@ -136,14 +130,14 @@ extension RPSpace {
             }
     }
     
-    public func getPendingEvents() -> [Event<Self>] {
+    public func getPendingEvents() -> [RPEvent<Self>] {
         allPendingGameMasterEvents() +
         getAllPendingPassiveEvents() +
         getAllPendingStatusEffectEvents() +
         getAllPendingExecutableEvents()
     }
 
-    public func getAllPendingPassiveEvents() -> [Event<Self>] {
+    public func getAllPendingPassiveEvents() -> [RPEvent<Self>] {
         allTeams()
             .compactMap(teamById)
             .flatMap(\.entities)
@@ -155,7 +149,7 @@ extension RPSpace {
     /// e.g. Regen and Bleed). Without this, status effects tick internally but
     /// their per-tick events are never collected, so only the ability's initial
     /// application is felt.
-    public func getAllPendingStatusEffectEvents() -> [Event<Self>] {
+    public func getAllPendingStatusEffectEvents() -> [RPEvent<Self>] {
         allTeams()
             .compactMap(teamById)
             .flatMap(\.entities)
@@ -163,7 +157,7 @@ extension RPSpace {
             .flatMap { $0.getPendingStatusEffectEvents(in: self) }
     }
 
-    public func getAllPendingExecutableEvents() -> [Event<Self>] {
+    public func getAllPendingExecutableEvents() -> [RPEvent<Self>] {
         allTeams()
             .compactMap(teamById)
             .flatMap(\.entities)
@@ -171,22 +165,22 @@ extension RPSpace {
             .flatMap { $0.getPendingExecutableEvents(in: self) }
     }
 
-    public mutating func performEvents(_ events: [Event<Self>]) -> [EventResult<Self>] {
+    public mutating func performEvents(_ events: [RPEvent<Self>]) -> [RPEventResult<Self>] {
         events.forEach { event in
             self.removeGameMasterEvent(id: event.id)
         }
 
         let mainEventResults = events
-            .flatMap { event -> [Event<Self>] in
+            .flatMap { event -> [RPEvent<Self>] in
                 event.resetInitiatorCooldowns(in: &self)
                 return [event]
             }
             .map { $0.execute(in: &self) }
         
         let reactionEventResults = mainEventResults.flatMap {
-            eventResult -> [Event<Self>] in
+            eventResult -> [RPEvent<Self>] in
             eventResult.effects.flatMap {
-                conflictResult -> [Event<Self>] in
+                conflictResult -> [RPEvent<Self>] in
                 entityById(conflictResult.entity)?.getPendingPassiveEvents(in: self) ?? []
             }
         }
@@ -197,7 +191,7 @@ extension RPSpace {
 
 }
 
-public struct ItemTransfer: Codable, Equatable {
+public struct RPItemTransfer: Codable, Equatable {
     public let itemId: RPItemId
     public let code: RPReferenceCode
     public let amount: Int
@@ -219,43 +213,29 @@ extension RPSpace {
         _ incoming: ActiveItem,
         to recipientId: RPEntityId,
         from sourceId: RPEntityId? = nil
-    ) -> [ItemTransfer] {
+    ) -> [RPItemTransfer] {
         guard incoming.amount > 0, entityById(recipientId) != nil else {
-            if itemById(incoming.id) != nil { removeItem(id: incoming.id) }
             return []
         }
-        var remaining = incoming.amount
-        var destinationId: RPItemId?
-        for stackId in entityById(recipientId)?.inventory ?? [] where stackId != incoming.id {
-            guard remaining > 0 else { break }
-            guard let stack = itemById(stackId), stack.code == incoming.code else { continue }
-            let capacity = stack.remainingCapacity ?? remaining
-            guard capacity > 0 else { continue }
-            let moved = Swift.min(remaining, capacity)
-            modifyItem(id: stackId) { s, _ in s.amount += moved }
-            remaining -= moved
-            if destinationId == nil { destinationId = stackId }
-        }
-        let existsInStore = itemById(incoming.id) != nil
-        if remaining > 0 {
-            if existsInStore {
-                modifyItem(id: incoming.id) { s, _ in
-                    s.amount = remaining
-                    s.entity = recipientId
-                }
-            } else {
+        modifyEntity(id: recipientId) { e, _ in
+            var remaining = incoming.amount
+            for index in e.inventory.indices {
+                guard remaining > 0 else { break }
+                guard e.inventory[index].code == incoming.code else { continue }
+                let capacity = e.inventory[index].remainingCapacity ?? remaining
+                guard capacity > 0 else { continue }
+                let moved = Swift.min(remaining, capacity)
+                e.inventory[index].amount += moved
+                remaining -= moved
+            }
+            if remaining > 0 {
                 var newStack = incoming
                 newStack.amount = remaining
-                newStack.entity = recipientId
-                addItem(newStack)
+                e.inventory.append(newStack)
             }
-            modifyEntity(id: recipientId) { e, _ in e.inventory.append(incoming.id) }
-            if destinationId == nil { destinationId = incoming.id }
-        } else if existsInStore {
-            removeItem(id: incoming.id)
         }
-        return [ItemTransfer(
-            itemId: destinationId ?? incoming.id,
+        return [RPItemTransfer(
+            itemId: incoming.id,
             code: incoming.code,
             amount: incoming.amount,
             from: sourceId,
@@ -264,32 +244,36 @@ extension RPSpace {
     }
 
     @discardableResult
-    public mutating func transferItem(id: RPItemId, to recipientId: RPEntityId) -> [ItemTransfer] {
-        guard let active = itemById(id), active.entity != recipientId else { return [] }
-        let sourceId = active.entity
-        if let sourceId = sourceId {
-            modifyEntity(id: sourceId) { e, _ in
-                e.inventory.removeAll { $0 == id }
-                e.body.wornItems.removeAll { $0 == id }
-            }
+    public mutating func transferItem(id: RPItemId, from sourceId: RPEntityId, to recipientId: RPEntityId) -> [RPItemTransfer] {
+        guard sourceId != recipientId, let source = entityById(sourceId) else { return [] }
+        guard let outgoing = (source.inventory + source.body.wornItems).first(where: { $0.id == id }) else {
+            return []
         }
-        return receiveItem(active, to: recipientId, from: sourceId)
+        modifyEntity(id: sourceId) { e, _ in
+            e.inventory.removeAll { $0.id == id }
+            e.body.wornItems.removeAll { $0.id == id }
+        }
+        return receiveItem(outgoing, to: recipientId, from: sourceId)
     }
 
     @discardableResult
-    public mutating func transferAllItems(from sourceId: RPEntityId, to recipientId: RPEntityId) -> [ItemTransfer] {
-        guard let source = entityById(sourceId) else { return [] }
-        let itemIds = source.inventory + source.body.wornItems.filter { !source.inventory.contains($0) }
-        return itemIds.flatMap { transferItem(id: $0, to: recipientId) }
+    public mutating func transferAllItems(from sourceId: RPEntityId, to recipientId: RPEntityId) -> [RPItemTransfer] {
+        guard sourceId != recipientId, let source = entityById(sourceId) else { return [] }
+        let outgoing = source.inventory + source.body.wornItems
+        modifyEntity(id: sourceId) { e, _ in
+            e.inventory = []
+            e.body.wornItems = []
+        }
+        return outgoing.flatMap { receiveItem($0, to: recipientId, from: sourceId) }
     }
 
-    public func collectAllEvent(from sourceId: RPEntityId, to recipientId: RPEntityId) -> Event<Self> {
-        Event(
+    public func collectAllEvent(from sourceId: RPEntityId, to recipientId: RPEntityId) -> RPEvent<Self> {
+        RPEvent(
             category: .itemExchangeOnly,
             initiator: sourceId,
-            ability: Ability<Self>(
+            ability: RPAbility<Self>(
                 code: "collect",
-                components: [Component(itemExchange: ItemExchange(kind: .transferAll))]
+                components: [Component(itemExchange: RPItemExchange(kind: .transferAll))]
             ),
             targets: [recipientId],
             rpSpace: self

--- a/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
+++ b/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
@@ -23,7 +23,7 @@ public protocol RPSpace: Codable {
     typealias Team = RPTeam<Self>
     associatedtype TeamSequence: Sequence where TeamSequence.Element == RPTeamId
 
-    typealias Item = RPItem<Self>
+    typealias ActiveItem = RPActiveItem<Self>
     associatedtype ItemSequence: Sequence where ItemSequence.Element == RPItemId
     
     static var statTypes: Set<String> { get }
@@ -49,8 +49,8 @@ public protocol RPSpace: Codable {
 
     func entityById(_ id: RPEntityId) -> Entity?
     func teamById(_ id: RPTeamId) -> Team?
-    func itemById(_ id: RPItemId) -> Item?
-    
+    func itemById(_ id: RPItemId) -> ActiveItem?
+
     func allEntities() -> EntitySequence
     func allTeams() -> TeamSequence
     func allItems() -> ItemSequence
@@ -58,13 +58,14 @@ public protocol RPSpace: Codable {
 
     mutating func addEntity(_ entity: Entity)
     mutating func setTeams(_ newTeams: [Team])
-    mutating func addItem(_ item: Item)
-    mutating func queueGameMasterEvent(ability: Ability<Self>, targets: Set<RPEntityId>)
+    mutating func addItem(_ item: ActiveItem)
+    mutating func removeItem(id: RPItemId)
+    mutating func queueGameMasterEvent(_ event: Event<Self>)
     mutating func removeGameMasterEvent(id: RPEventId)
-    
+
     mutating func modifyEntity(id: RPEntityId, perform: (inout Entity, Self) -> Void)
     mutating func modifyTeam(id: RPTeamId, perform: (inout Team, Self) -> Void)
-    mutating func modifyItem(id: RPItemId, perform: (inout Item, Self) -> Void)
+    mutating func modifyItem(id: RPItemId, perform: (inout ActiveItem, Self) -> Void)
 
 }
 
@@ -171,11 +172,10 @@ extension RPSpace {
     }
 
     public mutating func performEvents(_ events: [Event<Self>]) -> [EventResult<Self>] {
-        events.filter { $0.initiator == nil }
-        .forEach { event in
+        events.forEach { event in
             self.removeGameMasterEvent(id: event.id)
         }
-        
+
         let mainEventResults = events
             .flatMap { event -> [Event<Self>] in
                 event.resetInitiatorCooldowns(in: &self)
@@ -195,30 +195,104 @@ extension RPSpace {
         return mainEventResults + reactionEventResults
     }
 
-    // TODO: hook it in
-    public func give(item: RPItemId, to entity: RPEntityId) -> Event<Self> {
-        guard let entity = entityById(entity) else {
-            fatalError("no entity by that id")
+}
+
+public struct ItemTransfer: Codable, Equatable {
+    public let itemId: RPItemId
+    public let code: RPReferenceCode
+    public let amount: Int
+    public let from: RPEntityId?
+    public let to: RPEntityId
+
+    public init(itemId: RPItemId, code: RPReferenceCode, amount: Int, from: RPEntityId?, to: RPEntityId) {
+        self.itemId = itemId
+        self.code = code
+        self.amount = amount
+        self.from = from
+        self.to = to
+    }
+}
+
+extension RPSpace {
+    @discardableResult
+    public mutating func receiveItem(
+        _ incoming: ActiveItem,
+        to recipientId: RPEntityId,
+        from sourceId: RPEntityId? = nil
+    ) -> [ItemTransfer] {
+        guard incoming.amount > 0, entityById(recipientId) != nil else {
+            if itemById(incoming.id) != nil { removeItem(id: incoming.id) }
+            return []
         }
-        let exchange = Component<Self>(
-            itemExchange: ItemExchange(
-                exchangeType: .target,
-                requiresInitiatorOwnItem: false,
-                removesItemFromInitiator: false,
-                item: item
-            )
-        )
-        let targeting = Component<Self>(targetType: Targeting(.oneself, .always))
+        var remaining = incoming.amount
+        var destinationId: RPItemId?
+        for stackId in entityById(recipientId)?.inventory ?? [] where stackId != incoming.id {
+            guard remaining > 0 else { break }
+            guard let stack = itemById(stackId), stack.code == incoming.code else { continue }
+            let capacity = stack.remainingCapacity ?? remaining
+            guard capacity > 0 else { continue }
+            let moved = Swift.min(remaining, capacity)
+            modifyItem(id: stackId) { s, _ in s.amount += moved }
+            remaining -= moved
+            if destinationId == nil { destinationId = stackId }
+        }
+        let existsInStore = itemById(incoming.id) != nil
+        if remaining > 0 {
+            if existsInStore {
+                modifyItem(id: incoming.id) { s, _ in
+                    s.amount = remaining
+                    s.entity = recipientId
+                }
+            } else {
+                var newStack = incoming
+                newStack.amount = remaining
+                newStack.entity = recipientId
+                addItem(newStack)
+            }
+            modifyEntity(id: recipientId) { e, _ in e.inventory.append(incoming.id) }
+            if destinationId == nil { destinationId = incoming.id }
+        } else if existsInStore {
+            removeItem(id: incoming.id)
+        }
+        return [ItemTransfer(
+            itemId: destinationId ?? incoming.id,
+            code: incoming.code,
+            amount: incoming.amount,
+            from: sourceId,
+            to: recipientId
+        )]
+    }
 
-        let collect = Ability<Self>(
-            code: "",
-            components: [
-                exchange,
-                targeting,
-            ],
-            cooldown: nil
-        )
+    @discardableResult
+    public mutating func transferItem(id: RPItemId, to recipientId: RPEntityId) -> [ItemTransfer] {
+        guard let active = itemById(id), active.entity != recipientId else { return [] }
+        let sourceId = active.entity
+        if let sourceId = sourceId {
+            modifyEntity(id: sourceId) { e, _ in
+                e.inventory.removeAll { $0 == id }
+                e.body.wornItems.removeAll { $0 == id }
+            }
+        }
+        return receiveItem(active, to: recipientId, from: sourceId)
+    }
 
-        return Event<Self>(category: .itemExchangeOnly, initiator: entity.id, ability: collect, rpSpace: self)
+    @discardableResult
+    public mutating func transferAllItems(from sourceId: RPEntityId, to recipientId: RPEntityId) -> [ItemTransfer] {
+        guard let source = entityById(sourceId) else { return [] }
+        let itemIds = source.inventory + source.body.wornItems.filter { !source.inventory.contains($0) }
+        return itemIds.flatMap { transferItem(id: $0, to: recipientId) }
+    }
+
+    public func collectAllEvent(from sourceId: RPEntityId, to recipientId: RPEntityId) -> Event<Self> {
+        Event(
+            category: .itemExchangeOnly,
+            initiator: sourceId,
+            ability: Ability<Self>(
+                code: "collect",
+                components: [Component(itemExchange: ItemExchange(kind: .transferAll))]
+            ),
+            targets: [recipientId],
+            rpSpace: self
+        )
     }
 }

--- a/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
+++ b/Sources/RPTrunk/Foundation/RPSpace/RPSpace.swift
@@ -1,12 +1,22 @@
 public typealias RPEntityId = String
 public typealias RPTeamId = String
 public typealias RPItemId = String
+public typealias RPItemCacheId = String
 public typealias RPEventId = String
 
+public protocol RPMetadata: Codable & Equatable {}
+public struct EmptyMetadataDictionary: RPMetadata, Sendable {
+    public init() {}
+}
+
 public protocol RPSpace: Codable {
-    
+
     associatedtype Stats: StatsType
-    
+
+    associatedtype EntityMetadata: RPMetadata = EmptyMetadataDictionary
+    associatedtype ItemMetadata: RPMetadata = EmptyMetadataDictionary
+    associatedtype AbilityMetadata: RPMetadata = EmptyMetadataDictionary
+
     typealias Entity = RPEntity<Self>
     associatedtype EntitySequence: Sequence where EntitySequence.Element == RPEntityId
 

--- a/Sources/RPTrunk/Foundation/RPSpace/RPSpaceDictionary.swift
+++ b/Sources/RPTrunk/Foundation/RPSpace/RPSpaceDictionary.swift
@@ -8,36 +8,27 @@
 public protocol RPSpaceDictionary: RPSpace {
     var entities: [RPEntityId: RPEntity<Self>] { get set }
     var teams: [RPTeamId: RPTeam<Self>] { get set }
-    var items: [RPItemId: RPActiveItem<Self>] { get set }
-    var pendingGameMasterEvents: [Event<Self>] { get set }
+    var pendingGameMasterEvents: [RPEvent<Self>] { get set }
 }
 
 extension RPSpaceDictionary {
     public func allEntities() -> Dictionary<RPEntityId, RPEntity<Self>>.Keys {
         entities.keys
     }
-    
+
     public func allTeams() -> Dictionary<RPTeamId, RPTeam<Self>>.Keys  {
         teams.keys
     }
-    
-    public func allItems() -> Dictionary<RPItemId, RPActiveItem<Self>>.Keys  {
-        items.keys
-    }
-    
-    public func allPendingGameMasterEvents() -> [Event<Self>] {
+
+    public func allPendingGameMasterEvents() -> [RPEvent<Self>] {
         pendingGameMasterEvents
     }
-    
+
     public func entityById(_ id: RPEntityId) -> RPEntity<Self>? {
         entities[id]
     }
     public func teamById(_ id: RPTeamId) -> RPTeam<Self>? {
         teams[id]
-    }
-    
-    public func itemById(_ id: RPItemId) -> RPActiveItem<Self>? {
-        items[id]
     }
 
     public mutating func addEntity(_ entity: RPEntity<Self>) {
@@ -45,39 +36,24 @@ extension RPSpaceDictionary {
         entities[entity.id] = entity
     }
 
-    public mutating func addItem(_ item: RPActiveItem<Self>) {
-        assert(items[item.id] == nil, "attempting to add item that already exists in this space")
-        items[item.id] = item
-    }
-
-    public mutating func removeItem(id: RPItemId) {
-        items[id] = nil
-    }
-
-    public mutating func queueGameMasterEvent(_ event: Event<Self>) {
+    public mutating func queueGameMasterEvent(_ event: RPEvent<Self>) {
         pendingGameMasterEvents.append(event)
     }
-    
+
     public mutating func removeGameMasterEvent(id: RPEventId) {
         pendingGameMasterEvents.removeAll(where: { $0.id == id })
     }
-    
+
     public mutating func modifyEntity(id: RPEntityId, perform: (inout RPEntity<Self>, Self) -> Void) {
         guard var entity = entities[id] else { return }
         perform(&entity, self)
         entities[id] = entity
     }
-    
+
     public mutating func modifyTeam(id: RPTeamId, perform: (inout RPTeam<Self>, Self) -> Void) {
         guard var team = teams[id] else { return }
         perform(&team, self)
         teams[id] = team
-    }
-    
-    public mutating func modifyItem(id: RPItemId, perform: (inout RPActiveItem<Self>, Self) -> Void) {
-        guard var item = items[id] else { return }
-        perform(&item, self)
-        items[id] = item
     }
 
     public mutating func setTeams(_ newTeams: [RPTeam<Self>]) {

--- a/Sources/RPTrunk/Foundation/RPSpace/RPSpaceDictionary.swift
+++ b/Sources/RPTrunk/Foundation/RPSpace/RPSpaceDictionary.swift
@@ -8,7 +8,7 @@
 public protocol RPSpaceDictionary: RPSpace {
     var entities: [RPEntityId: RPEntity<Self>] { get set }
     var teams: [RPTeamId: RPTeam<Self>] { get set }
-    var items: [RPItemId: RPItem<Self>] { get set }
+    var items: [RPItemId: RPActiveItem<Self>] { get set }
     var pendingGameMasterEvents: [Event<Self>] { get set }
 }
 
@@ -21,7 +21,7 @@ extension RPSpaceDictionary {
         teams.keys
     }
     
-    public func allItems() -> Dictionary<RPItemId, RPItem<Self>>.Keys  {
+    public func allItems() -> Dictionary<RPItemId, RPActiveItem<Self>>.Keys  {
         items.keys
     }
     
@@ -36,22 +36,26 @@ extension RPSpaceDictionary {
         teams[id]
     }
     
-    public func itemById(_ id: RPItemId) -> RPItem<Self>? {
+    public func itemById(_ id: RPItemId) -> RPActiveItem<Self>? {
         items[id]
     }
-    
+
     public mutating func addEntity(_ entity: RPEntity<Self>) {
         assert(entities[entity.id] == nil, "attempting to add entity that already exists in this space")
         entities[entity.id] = entity
     }
-    
-    public mutating func addItem(_ item: RPItem<Self>) {
+
+    public mutating func addItem(_ item: RPActiveItem<Self>) {
         assert(items[item.id] == nil, "attempting to add item that already exists in this space")
         items[item.id] = item
     }
-    
-    public mutating func queueGameMasterEvent(ability: Ability<Self>, targets: Set<RPEntityId>) {
-        pendingGameMasterEvents.append(.init(ability: ability, targets: targets))
+
+    public mutating func removeItem(id: RPItemId) {
+        items[id] = nil
+    }
+
+    public mutating func queueGameMasterEvent(_ event: Event<Self>) {
+        pendingGameMasterEvents.append(event)
     }
     
     public mutating func removeGameMasterEvent(id: RPEventId) {
@@ -70,7 +74,7 @@ extension RPSpaceDictionary {
         teams[id] = team
     }
     
-    public mutating func modifyItem(id: RPItemId, perform: (inout RPItem<Self>, Self) -> Void) {
+    public mutating func modifyItem(id: RPItemId, perform: (inout RPActiveItem<Self>, Self) -> Void) {
         guard var item = items[id] else { return }
         perform(&item, self)
         items[id] = item

--- a/Sources/RPTrunk/Foundation/RPTeam.swift
+++ b/Sources/RPTrunk/Foundation/RPTeam.swift
@@ -4,7 +4,7 @@ public struct RPTeam<RP: RPSpace>: InventoryManager, Codable, Equatable {
     public var allies: Set<RPTeamId> = []
     public var enemies: Set<RPTeamId> = []
 
-    public var inventory: [RPItemId] = []
+    public var inventory: [RPActiveItem<RP>] = []
     
     public init() { }
 

--- a/Sources/RPTrunk/Foundation/StatusEffect.swift
+++ b/Sources/RPTrunk/Foundation/StatusEffect.swift
@@ -1,5 +1,5 @@
 
-public struct StatusEffect<RP: RPSpace>: Codable {
+public struct RPStatusEffect<RP: RPSpace>: Codable {
     /// Default time between pulses (ms) when a status effect doesn't specify one.
     public static var defaultPeriod: RPTimeIncrement { 1000 }
 
@@ -12,7 +12,7 @@ public struct StatusEffect<RP: RPSpace>: Codable {
     let impairsAction: Bool
     /// Time (ms) between periodic pulses of this effect (heal/damage over time).
     let period: RPTimeIncrement
-    let ability: Ability<RP>?
+    let ability: RPAbility<RP>?
 
     public init(
         code: RPReferenceCode,
@@ -22,7 +22,7 @@ public struct StatusEffect<RP: RPSpace>: Codable {
         duration: Double?,
         charges: Int?,
         impairsAction: Bool = false,
-        period: RPTimeIncrement = StatusEffect.defaultPeriod
+        period: RPTimeIncrement = RPStatusEffect.defaultPeriod
     ) {
         self.code = code
         self.displayName = displayName ?? code
@@ -33,21 +33,21 @@ public struct StatusEffect<RP: RPSpace>: Codable {
         self.period = period
 
         if components.count > 0 {
-            let components: [Component<RP>] = components + [Targeting<RP>(.oneself, .always).toComponent()]
-            ability = Ability(code: code, displayName: displayName, components: components, cooldown: nil)
+            let components: [Component<RP>] = components + [RPTargeting<RP>(.oneself, .always).toComponent()]
+            ability = RPAbility(code: code, displayName: displayName, components: components, cooldown: nil)
         } else {
             ability = nil
         }
     }
 
-    public func getStatusEffects() -> [StatusEffect] {
+    public func getStatusEffects() -> [RPStatusEffect] {
         [self]
     }
 }
 
-extension StatusEffect: Equatable {}
+extension RPStatusEffect: Equatable {}
 
-public func ==<Stats: StatsType> (lhs: StatusEffect<Stats>, rhs: StatusEffect<Stats>) -> Bool {
+public func ==<Stats: StatsType> (lhs: RPStatusEffect<Stats>, rhs: RPStatusEffect<Stats>) -> Bool {
     lhs.code == rhs.code
         && lhs.tags == rhs.tags
         && lhs.ability == rhs.ability
@@ -55,7 +55,7 @@ public func ==<Stats: StatsType> (lhs: StatusEffect<Stats>, rhs: StatusEffect<St
 /**
     A Status effect, currently active on an entity
  */
-public struct ActiveStatusEffect<RP: RPSpace>: Temporal, Codable {
+public struct RPActiveStatusEffect<RP: RPSpace>: Temporal, Codable {
     public var deltaTick: RPTimeIncrement = 0
     public var currentTick: RPTimeIncrement = 0
     public var maximumTick: RPTimeIncrement { statusEffect.duration ?? 0 }
@@ -65,7 +65,7 @@ public struct ActiveStatusEffect<RP: RPSpace>: Temporal, Codable {
     var level: Int? // power level of the buff, if it is stackable
 
     public var entityId: RPEntityId
-    fileprivate let statusEffect: StatusEffect<RP>
+    fileprivate let statusEffect: RPStatusEffect<RP>
 
     public var code: RPReferenceCode { statusEffect.code }
     public var displayName: String { statusEffect.displayName }
@@ -73,7 +73,7 @@ public struct ActiveStatusEffect<RP: RPSpace>: Temporal, Codable {
 
     public init(
         entityId: RPEntityId,
-        statusEffect: StatusEffect<RP>
+        statusEffect: RPStatusEffect<RP>
     ) {
         self.entityId = entityId
         self.statusEffect = statusEffect
@@ -84,18 +84,18 @@ public struct ActiveStatusEffect<RP: RPSpace>: Temporal, Codable {
         statusEffect.impairsAction
     }
 
-    public func getPendingEvents(in rpSpace: RP) -> [Event<RP>] {
+    public func getPendingEvents(in rpSpace: RP) -> [RPEvent<RP>] {
         // Pulse once the accumulated time reaches the effect's configured period.
         guard deltaTick >= statusEffect.period else {
             return []
         }
         if let ability = statusEffect.ability {
-            return [Event(category: .periodicEffect(name: code), initiator: entityId, ability: ability, rpSpace: rpSpace)]
+            return [RPEvent(category: .periodicEffect(name: code), initiator: entityId, ability: ability, rpSpace: rpSpace)]
         }
         return []
     }
 
-    public mutating func tick(_ moment: Moment) {
+    public mutating func tick(_ moment: RPMoment) {
         guard isCoolingDown() else {
             return
         }

--- a/Sources/RPTrunk/Foundation/StatusEffect.swift
+++ b/Sources/RPTrunk/Foundation/StatusEffect.swift
@@ -3,7 +3,8 @@ public struct StatusEffect<RP: RPSpace>: Codable {
     /// Default time between pulses (ms) when a status effect doesn't specify one.
     public static var defaultPeriod: RPTimeIncrement { 1000 }
 
-    public let name: String
+    public let code: RPReferenceCode
+    public let displayName: String
     public let tags: [String]
     // both duration and charge can be used or one or the other
     let duration: RPTimeIncrement?
@@ -14,7 +15,8 @@ public struct StatusEffect<RP: RPSpace>: Codable {
     let ability: Ability<RP>?
 
     public init(
-        name: String,
+        code: RPReferenceCode,
+        displayName: String? = nil,
         tags: [String],
         components: [Component<RP>],
         duration: Double?,
@@ -22,7 +24,8 @@ public struct StatusEffect<RP: RPSpace>: Codable {
         impairsAction: Bool = false,
         period: RPTimeIncrement = StatusEffect.defaultPeriod
     ) {
-        self.name = name
+        self.code = code
+        self.displayName = displayName ?? code
         self.tags = tags
         self.duration = duration
         self.charges = charges
@@ -31,7 +34,7 @@ public struct StatusEffect<RP: RPSpace>: Codable {
 
         if components.count > 0 {
             let components: [Component<RP>] = components + [Targeting<RP>(.oneself, .always).toComponent()]
-            ability = Ability(name: name, components: components, cooldown: nil)
+            ability = Ability(code: code, displayName: displayName, components: components, cooldown: nil)
         } else {
             ability = nil
         }
@@ -45,7 +48,7 @@ public struct StatusEffect<RP: RPSpace>: Codable {
 extension StatusEffect: Equatable {}
 
 public func ==<Stats: StatsType> (lhs: StatusEffect<Stats>, rhs: StatusEffect<Stats>) -> Bool {
-    lhs.name == rhs.name
+    lhs.code == rhs.code
         && lhs.tags == rhs.tags
         && lhs.ability == rhs.ability
 }
@@ -64,7 +67,8 @@ public struct ActiveStatusEffect<RP: RPSpace>: Temporal, Codable {
     public var entityId: RPEntityId
     fileprivate let statusEffect: StatusEffect<RP>
 
-    public var name: String { statusEffect.name }
+    public var code: RPReferenceCode { statusEffect.code }
+    public var displayName: String { statusEffect.displayName }
     public var tags: [String] { statusEffect.tags }
 
     public init(
@@ -86,7 +90,7 @@ public struct ActiveStatusEffect<RP: RPSpace>: Temporal, Codable {
             return []
         }
         if let ability = statusEffect.ability {
-            return [Event(category: .periodicEffect(name: name), initiator: entityId, ability: ability, rpSpace: rpSpace)]
+            return [Event(category: .periodicEffect(name: code), initiator: entityId, ability: ability, rpSpace: rpSpace)]
         }
         return []
     }

--- a/Sources/RPTrunk/Foundation/Targeting.swift
+++ b/Sources/RPTrunk/Foundation/Targeting.swift
@@ -1,4 +1,4 @@
-public struct Targeting<RP: RPSpace>: Codable {
+public struct RPTargeting<RP: RPSpace>: Codable {
     public enum SelectionType: String, Codable {
         case oneself
         case random
@@ -76,8 +76,8 @@ public struct Targeting<RP: RPSpace>: Codable {
     }
 }
 
-public extension Targeting {
-    static func fromString(_ query: String) -> Targeting {
+public extension RPTargeting {
+    static func fromString(_ query: String) -> RPTargeting {
         let components = query.split(separator: ":", omittingEmptySubsequences: false)
         guard let type = components.first.map(String.init) else {
             fatalError("Unexpected format for string translation to target")
@@ -87,38 +87,38 @@ public extension Targeting {
 
         switch type {
         case "self":
-            return Targeting(.oneself, condition)
+            return RPTargeting(.oneself, condition)
         case "enemy":
-            return Targeting(.singleEnemy, condition)
+            return RPTargeting(.singleEnemy, condition)
         case "all":
-            return Targeting(.all, condition)
+            return RPTargeting(.all, condition)
         case "random":
-            return Targeting(.random, condition)
+            return RPTargeting(.random, condition)
         case "allFriendlies":
-            return Targeting(.allFriendly, condition)
+            return RPTargeting(.allFriendly, condition)
         case "allEnemies":
-            return Targeting(.allEnemy, condition)
+            return RPTargeting(.allEnemy, condition)
         case "ally", "singleFriendly":
-            return Targeting(.singleFriendly, condition)
+            return RPTargeting(.singleFriendly, condition)
         case "randomFriendly":
-            return Targeting(.randomFriendly, condition)
+            return RPTargeting(.randomFriendly, condition)
         case "randomEnemy":
-            return Targeting(.randomEnemy, condition)
+            return RPTargeting(.randomEnemy, condition)
         case "allyTeam":
-            return Targeting(.allyTeam, condition)
+            return RPTargeting(.allyTeam, condition)
         default:
-            return Targeting(.all, condition) // type would be the condition in this case
+            return RPTargeting(.all, condition) // type would be the condition in this case
         }
     }
 }
 
-extension Targeting: Equatable {}
+extension RPTargeting: Equatable {}
 
-public func == <RP: RPSpace>(lhs: Targeting<RP>, rhs: Targeting<RP>) -> Bool {
+public func == <RP: RPSpace>(lhs: RPTargeting<RP>, rhs: RPTargeting<RP>) -> Bool {
     lhs.type == rhs.type && lhs.conditional == rhs.conditional
 }
 
-extension Targeting {
+extension RPTargeting {
     func toComponent() -> Component<RP> {
         Component<RP>(targetType: self)
     }

--- a/Sources/RPTrunk/Foundation/Temporal.swift
+++ b/Sources/RPTrunk/Foundation/Temporal.swift
@@ -1,6 +1,6 @@
 public typealias RPTimeIncrement = Double
 
-public struct Moment {
+public struct RPMoment {
     public let delta: RPTimeIncrement
 
     public init(delta: RPTimeIncrement) {
@@ -13,10 +13,10 @@ public protocol Temporal {
     var currentTick: RPTimeIncrement { get set }
     var maximumTick: RPTimeIncrement { get }
 
-    mutating func tick(_ moment: Moment)
+    mutating func tick(_ moment: RPMoment)
     mutating func resetCooldown()
 
-    func getPendingEvents(in rpSpace: RP) -> [Event<RP>]
+    func getPendingEvents(in rpSpace: RP) -> [RPEvent<RP>]
 }
 
 extension Temporal {

--- a/Sources/RPTrunk/Foundation/Threat.swift
+++ b/Sources/RPTrunk/Foundation/Threat.swift
@@ -19,7 +19,7 @@ public struct ThreatChange: Equatable, Codable {
 public extension RPSpace {
     /// This default produces no threat, leaving the feature dormant until this function is implemented
     static func resolveThreatChanges(
-        for eventResult: EventResult<Self>,
+        for eventResult: RPEventResult<Self>,
         in rpSpace: Self
     ) -> [ThreatChange] {
         []

--- a/Tests/RPTrunkTests/EntityTests.swift
+++ b/Tests/RPTrunkTests/EntityTests.swift
@@ -41,12 +41,12 @@ final class EntityTests: XCTestCase {
     }
     
     func test_entity_stats_are_sum_of_components() {
-        let sword = RPItem<TestRPSpace>(components: [
+        let sword = RPActiveItem<TestRPSpace>(item: RPItem(code: "sword", components: [
             Component(stats: .init(dict: [\.damage: 10]))
-        ])
-        let helmet = RPItem<TestRPSpace>(components: [
+        ]))
+        let helmet = RPActiveItem<TestRPSpace>(item: RPItem(code: "helmet", components: [
             Component(stats: .init(dict: [\.damage: 5]))
-        ])
+        ]))
         
         rpSpace.items[sword.id] = sword
         rpSpace.items[helmet.id] = helmet

--- a/Tests/RPTrunkTests/EntityTests.swift
+++ b/Tests/RPTrunkTests/EntityTests.swift
@@ -59,10 +59,10 @@ final class EntityTests: XCTestCase {
     }
 
     func test_passive_abilities_should_trigger_on_event_occurrences() {
-        let ability = Ability<TestRPSpace>(name: "Test")
+        let ability = Ability<TestRPSpace>(code: "Test")
         rpSpace.entities[entity.id]?.addPassiveAbility(ability, conditional: .always)
 
-        let enemyAbility = Ability<TestRPSpace>(name: "enemyAbility")
+        let enemyAbility = Ability<TestRPSpace>(code: "enemyAbility")
         let fakeEvent = Event(initiator: enemy.id, ability: enemyAbility, rpSpace: rpSpace)
 
         _ = fakeEvent.execute(in: &rpSpace)
@@ -72,7 +72,7 @@ final class EntityTests: XCTestCase {
     }
 
     func test_status_effects_should_be_able_to_remove_status_effect_by_name() {
-        let se = StatusEffect<TestRPSpace>(name: "Death", tags: ["KO"], components: [], duration: nil, charges: 1)
+        let se = StatusEffect<TestRPSpace>(code: "Death", tags: ["KO"], components: [], duration: nil, charges: 1)
         entity.applyStatusEffect(se)
 
         XCTAssertEqual(entity.hasStatus("Death"), true)
@@ -82,7 +82,7 @@ final class EntityTests: XCTestCase {
     }
 
     func test_status_effects_discharges_to_remove_a_status_effect_with_multiple_charges() {
-        let se = StatusEffect<TestRPSpace>(name: "Charge", tags: ["boost"], components: [], duration: nil, charges: 2)
+        let se = StatusEffect<TestRPSpace>(code: "Charge", tags: ["boost"], components: [], duration: nil, charges: 2)
         entity.applyStatusEffect(se)
 
         XCTAssertEqual(entity.hasStatus("Charge"), true)

--- a/Tests/RPTrunkTests/EntityTests.swift
+++ b/Tests/RPTrunkTests/EntityTests.swift
@@ -48,9 +48,7 @@ final class EntityTests: XCTestCase {
             Component(stats: .init(dict: [\.damage: 5]))
         ]))
         
-        rpSpace.items[sword.id] = sword
-        rpSpace.items[helmet.id] = helmet
-        entity.body.wornItems = [sword.id, helmet.id]
+        entity.body.wornItems = [sword, helmet]
         
         XCTAssertEqual(entity.getTotalStats(in: rpSpace).damage, 15)
         
@@ -59,11 +57,11 @@ final class EntityTests: XCTestCase {
     }
 
     func test_passive_abilities_should_trigger_on_event_occurrences() {
-        let ability = Ability<TestRPSpace>(code: "Test")
+        let ability = RPAbility<TestRPSpace>(code: "Test")
         rpSpace.entities[entity.id]?.addPassiveAbility(ability, conditional: .always)
 
-        let enemyAbility = Ability<TestRPSpace>(code: "enemyAbility")
-        let fakeEvent = Event(initiator: enemy.id, ability: enemyAbility, rpSpace: rpSpace)
+        let enemyAbility = RPAbility<TestRPSpace>(code: "enemyAbility")
+        let fakeEvent = RPEvent(initiator: enemy.id, ability: enemyAbility, rpSpace: rpSpace)
 
         _ = fakeEvent.execute(in: &rpSpace)
         let reactionEvents = rpSpace.entities[entity.id]?.getPendingPassiveEvents(in: rpSpace)
@@ -72,7 +70,7 @@ final class EntityTests: XCTestCase {
     }
 
     func test_status_effects_should_be_able_to_remove_status_effect_by_name() {
-        let se = StatusEffect<TestRPSpace>(code: "Death", tags: ["KO"], components: [], duration: nil, charges: 1)
+        let se = RPStatusEffect<TestRPSpace>(code: "Death", tags: ["KO"], components: [], duration: nil, charges: 1)
         entity.applyStatusEffect(se)
 
         XCTAssertEqual(entity.hasStatus("Death"), true)
@@ -82,7 +80,7 @@ final class EntityTests: XCTestCase {
     }
 
     func test_status_effects_discharges_to_remove_a_status_effect_with_multiple_charges() {
-        let se = StatusEffect<TestRPSpace>(code: "Charge", tags: ["boost"], components: [], duration: nil, charges: 2)
+        let se = RPStatusEffect<TestRPSpace>(code: "Charge", tags: ["boost"], components: [], duration: nil, charges: 2)
         entity.applyStatusEffect(se)
 
         XCTAssertEqual(entity.hasStatus("Charge"), true)

--- a/Tests/RPTrunkTests/ParserTests.swift
+++ b/Tests/RPTrunkTests/ParserTests.swift
@@ -230,7 +230,7 @@ final class ParserTests: XCTestCase {
         let dyingQuery2: Conditional<TestRPSpace>.Predicate = try interpretStringCondition("   Dieing?    ==   false  ")
 
         let statusEffect = StatusEffect<TestRPSpace>(
-            name: "Healing",
+            code: "Healing",
             tags: [],
             components: [],
             duration: 1,

--- a/Tests/RPTrunkTests/ParserTests.swift
+++ b/Tests/RPTrunkTests/ParserTests.swift
@@ -229,7 +229,7 @@ final class ParserTests: XCTestCase {
         let dyingQuery: Conditional<TestRPSpace>.Predicate = try interpretStringCondition("   Dieing?   ")
         let dyingQuery2: Conditional<TestRPSpace>.Predicate = try interpretStringCondition("   Dieing?    ==   false  ")
 
-        let statusEffect = StatusEffect<TestRPSpace>(
+        let statusEffect = RPStatusEffect<TestRPSpace>(
             code: "Healing",
             tags: [],
             components: [],

--- a/Tests/RPTrunkTests/StatusEffectsTests.swift
+++ b/Tests/RPTrunkTests/StatusEffectsTests.swift
@@ -18,7 +18,7 @@ final class StatusEffectsTests: XCTestCase {
 
     func testPeriodicStatusEffectEventsAndDecay() {
         let se = StatusEffect<TestRPSpace>(
-            name: "Test",
+            code: "Test",
             tags: [],
             components: [
                 Component(stats: .init(dict: [\.hp: 1]))

--- a/Tests/RPTrunkTests/StatusEffectsTests.swift
+++ b/Tests/RPTrunkTests/StatusEffectsTests.swift
@@ -17,7 +17,7 @@ final class StatusEffectsTests: XCTestCase {
     }
 
     func testPeriodicStatusEffectEventsAndDecay() {
-        let se = StatusEffect<TestRPSpace>(
+        let se = RPStatusEffect<TestRPSpace>(
             code: "Test",
             tags: [],
             components: [
@@ -26,7 +26,7 @@ final class StatusEffectsTests: XCTestCase {
             duration: 2,
             charges: nil
         )
-        var activeSE = ActiveStatusEffect(entityId: "abcd", statusEffect: se)
+        var activeSE = RPActiveStatusEffect(entityId: "abcd", statusEffect: se)
 
         XCTAssertEqual(activeSE.isCoolingDown(), true)
         XCTAssertEqual(activeSE.getPendingEvents(in: rpSpace).count, 0)

--- a/Tests/RPTrunkTests/TestGame/TestRPSpace.swift
+++ b/Tests/RPTrunkTests/TestGame/TestRPSpace.swift
@@ -6,25 +6,24 @@ public struct TestRPSpace: RPSpaceDictionary, Equatable {
     
     public var entities: [RPEntityId: RPEntity<Self>] = [:]
     public var teams: [RPTeamId: RPTeam<Self>] = [:]
-    public var items: [RPItemId: RPActiveItem<Self>] = [:]
-    public var pendingGameMasterEvents: [Event<TestRPSpace>] = []
+    public var pendingGameMasterEvents: [RPEvent<TestRPSpace>] = []
 
     public init() {}
 
     /// Test hook: lets individual tests define how events produce threat.
-    nonisolated(unsafe) static var threatRule: ((EventResult<TestRPSpace>) -> [ThreatChange])?
+    nonisolated(unsafe) static var threatRule: ((RPEventResult<TestRPSpace>) -> [ThreatChange])?
 
     public static func resolveThreatChanges(
-        for eventResult: EventResult<TestRPSpace>,
+        for eventResult: RPEventResult<TestRPSpace>,
         in rpSpace: TestRPSpace
     ) -> [ThreatChange] {
         threatRule?(eventResult) ?? []
     }
     
-    public static func resolveConflict(_ event: Event<Self>, in rpSpace: Self, target: RPEntityId, conflict: Stats) -> ConflictResult<Self> {
+    public static func resolveConflict(_ event: RPEvent<Self>, in rpSpace: Self, target: RPEntityId, conflict: Stats) -> ConflictResult<Self> {
         ConflictResult(.init(), .zero)
         //    public func resolveConflict(
-        //        _ event: Event,
+        //        _ event: RPEvent,
         //        in rpSpace: RPSpace,
         //        target: RPEntityId,
         //        conflict: Stats

--- a/Tests/RPTrunkTests/TestGame/TestRPSpace.swift
+++ b/Tests/RPTrunkTests/TestGame/TestRPSpace.swift
@@ -6,7 +6,7 @@ public struct TestRPSpace: RPSpaceDictionary, Equatable {
     
     public var entities: [RPEntityId: RPEntity<Self>] = [:]
     public var teams: [RPTeamId: RPTeam<Self>] = [:]
-    public var items: [RPItemId: RPItem<Self>] = [:]
+    public var items: [RPItemId: RPActiveItem<Self>] = [:]
     public var pendingGameMasterEvents: [Event<TestRPSpace>] = []
 
     public init() {}

--- a/Tests/RPTrunkTests/ThreatTests.swift
+++ b/Tests/RPTrunkTests/ThreatTests.swift
@@ -67,7 +67,7 @@ final class ThreatTests: XCTestCase {
         space.addEntity(allyB)
         space.setTeams([team])
 
-        let targeting = Targeting<TestRPSpace>(.singleFriendly, .always)
+        let targeting = RPTargeting<TestRPSpace>(.singleFriendly, .always)
         XCTAssertEqual(targeting.getValidTargets(for: "healer", in: space), ["ally-a"])
     }
 
@@ -95,17 +95,17 @@ final class ThreatTests: XCTestCase {
         entity.threatDecayPerTick = 2
         entity.addThreat(toward: "a", amount: 5)
 
-        entity.tick(Moment(delta: 1)) // -2 -> 3
+        entity.tick(RPMoment(delta: 1)) // -2 -> 3
         XCTAssertEqual(entity.threat["a"], 3)
 
-        entity.tick(Moment(delta: 2)) // -4 -> clamped out
+        entity.tick(RPMoment(delta: 2)) // -4 -> clamped out
         XCTAssertFalse(entity.holdsThreat(toward: "a"))
     }
 
     func testDecayDisabledByDefault() {
         var entity = RPEntity<TestRPSpace>(["hp": 10])
         entity.addThreat(toward: "a", amount: 5)
-        entity.tick(Moment(delta: 100))
+        entity.tick(RPMoment(delta: 100))
         XCTAssertEqual(entity.threat["a"], 5)
     }
 
@@ -137,7 +137,7 @@ final class ThreatTests: XCTestCase {
         XCTAssertEqual(rpSpace.entityById("attacker")?.threat.isEmpty, true)
     }
 
-    // MARK: - Event pipeline integration
+    // MARK: - RPEvent pipeline integration
 
     func makeCombatSpace() -> (TestRPSpace, attacker: RPEntityId, target: RPEntityId) {
         var attacker = RPEntity<TestRPSpace>(["hp": 30, "damage": 4])
@@ -159,15 +159,15 @@ final class ThreatTests: XCTestCase {
         return (space, attacker.id, target.id)
     }
 
-    func makeAttack() -> Ability<TestRPSpace> {
+    func makeAttack() -> RPAbility<TestRPSpace> {
         var stats = TestStats()
         stats.damage = 4
-        return Ability(code: "Attack", components: [Component(stats: stats)])
+        return RPAbility(code: "Attack", components: [Component(stats: stats)])
     }
 
     func testEventsProduceNoThreatByDefault() {
         var (space, attackerId, targetId) = makeCombatSpace()
-        let event = Event(initiator: attackerId, ability: makeAttack(), rpSpace: space)
+        let event = RPEvent(initiator: attackerId, ability: makeAttack(), rpSpace: space)
 
         _ = space.performEvents([event])
 
@@ -188,7 +188,7 @@ final class ThreatTests: XCTestCase {
             }
         }
 
-        let event = Event(initiator: attackerId, ability: makeAttack(), rpSpace: space)
+        let event = RPEvent(initiator: attackerId, ability: makeAttack(), rpSpace: space)
         _ = space.performEvents([event])
 
         let victim = space.entityById(targetId)

--- a/Tests/RPTrunkTests/ThreatTests.swift
+++ b/Tests/RPTrunkTests/ThreatTests.swift
@@ -162,7 +162,7 @@ final class ThreatTests: XCTestCase {
     func makeAttack() -> Ability<TestRPSpace> {
         var stats = TestStats()
         stats.damage = 4
-        return Ability(name: "Attack", components: [Component(stats: stats)])
+        return Ability(code: "Attack", components: [Component(stats: stats)])
     }
 
     func testEventsProduceNoThreatByDefault() {


### PR DESCRIPTION
## What

Adds an item **data cache** to RPTrunk so consumers can define items in RP data and mint instances, in support of dungeon-cleaners' new collectible-item system.

- **`CacheJSON.swift`** — new `Items` top-level key in `RPCacheJSON` and a new `ItemJSON<Stats>` (mirrors `AbilityJSON`: stats/cost/requirements/statusEffects/target/discharge/components, plus `ability` name-ref, `conditional`, `cooldown`, `metadata`).
- **`Cache.swift`** — `RPCache.items: [String: RPItem<RP>]`, `loadItems(_:)` (resolves the item's ability from the cache, builds components/conditional/metadata), and `newItem(_:)` that copies a template with a fresh id (mirrors `newEntity`).
- **`RPItem.swift`** — added `metadata: [String: String]?` (mirrors `Ability.metadata`) for game-side presentation (sprite id/frame, collect behavior).
- **`Equipment.swift`** — `Body.wornItems` made `public` (+ `public init()`) so a consumer can equip an item id and have `getTotalStats` sum its stats.

## Notes
- No item-existence conditional grammar was added (deferred by design); the runtime data is already reachable via `RPSpace`.
- One pre-existing test failure (`testPeriodicStatusEffectEventsAndDecay`) is unrelated — it fails identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)